### PR TITLE
Update versions of o11y components

### DIFF
--- a/argocd/applications/templates/alerting-monitor.yaml
+++ b/argocd/applications/templates/alerting-monitor.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: o11y/charts/{{$appName}}
-      targetRevision: 1.6.27
+      targetRevision: 1.7.0
       helm:
         releaseName: {{$appName}}
         valuesObject:

--- a/argocd/applications/templates/edgenode-dashboards.yaml
+++ b/argocd/applications/templates/edgenode-dashboards.yaml
@@ -19,7 +19,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: o11y/charts/{{$appName}}
-      targetRevision: 0.2.28
+      targetRevision: 0.3.0
       helm:
         releaseName: {{$appName}}
         valuesObject:

--- a/argocd/applications/templates/edgenode-observability.yaml
+++ b/argocd/applications/templates/edgenode-observability.yaml
@@ -19,7 +19,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: o11y/charts/{{$appName}}
-      targetRevision: 0.9.14
+      targetRevision: 0.10.0
       helm:
         releaseName: {{$appName}}
         valuesObject:

--- a/argocd/applications/templates/observability-tenant-controller.yaml
+++ b/argocd/applications/templates/observability-tenant-controller.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: o11y/charts/{{$appName}}
-      targetRevision: 0.5.40
+      targetRevision: 0.6.0
       helm:
         releaseName: {{$appName}}
         valuesObject:

--- a/argocd/applications/templates/orchestrator-dashboards.yaml
+++ b/argocd/applications/templates/orchestrator-dashboards.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: o11y/charts/{{$appName}}
-      targetRevision: 0.2.16
+      targetRevision: 0.3.0
       helm:
         releaseName: {{$appName}}
         valuesObject:

--- a/argocd/applications/templates/orchestrator-observability.yaml
+++ b/argocd/applications/templates/orchestrator-observability.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: o11y/charts/{{$appName}}
-      targetRevision: 0.4.11
+      targetRevision: 0.5.0
       helm:
         releaseName: {{$appName}}
         valuesObject:

--- a/argocd/applications/templates/sre-exporter.yaml
+++ b/argocd/applications/templates/sre-exporter.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: o11y/charts/{{$appName}}
-      targetRevision: 0.8.19
+      targetRevision: 0.9.0
       helm:
         releaseName: {{$appName}}
         valuesObject:


### PR DESCRIPTION
Updates for o11y component versions:

- alerting-monitor
- observability-tenant-controller
- sre-exporter
- edgenode-dashboards
- edgenode-observability
- orchestrator-dashboards
- orchestrator-observability