### PR TITLE
Update cluster-extensions manifest to include kubernetes dashboard extension

### DIFF
--- a/argocd/applications/custom/app-orch-tenant-controller.tpl
+++ b/argocd/applications/custom/app-orch-tenant-controller.tpl
@@ -28,7 +28,7 @@ configProvisioner:
   releaseServiceRootUrl: oci://{{ .Values.argo.releaseService.ociRegistry }}
   {{- end}}
 
-  manifestTag: "v1.0.25"
+  manifestTag: "v1.0.26"
 
   # http proxy settings
   {{- if .Values.argo.proxy.httpProxy}}


### PR DESCRIPTION
Updates cluster-extensions to 1.0.25 which includes the new kubernetes dashboard extension