### PR TITLE
Disable external SRE secret

### DIFF
--- a/e2e-tests/config/expected/clusters/dev-coder.yaml
+++ b/e2e-tests/config/expected/clusters/dev-coder.yaml
@@ -50,7 +50,6 @@ argo:
   o11y:
     sre:
       customerLabel: local
-      externalSecretsEnabled: true
       providerSecretName: sre-secret
 
   aws:

--- a/orch-configs/profiles/profile-aws.yaml
+++ b/orch-configs/profiles/profile-aws.yaml
@@ -66,7 +66,6 @@ argo:
         storageClass: gp3
     orchestrator: {}
     sre:
-      externalSecretsEnabled: true
       tls:
         enabled: true
 


### PR DESCRIPTION
### Description

In the latest change, we disable the ASM from clusters. Which cause SRE exporter external secret store not able to access ASM proxy.

We need to let SRE exporter to read kubernetes secrets directly instead of using external secret

### How Has This Been Tested?

To be tested with cluster once #28 is merged

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
