### PR TITLE
fix: keys of sre secrets in TF match component level values

### DIFF
--- a/pod-configs/module/orch-init/main.tf
+++ b/pod-configs/module/orch-init/main.tf
@@ -156,7 +156,7 @@ resource "kubernetes_secret" "sre_destination_secret_url" {
     namespace = "orch-sre"
   }
   data = {
-    "password" = var.sre_destination_secret_url
+    "url" = var.sre_destination_secret_url
   }
 }
 
@@ -168,7 +168,7 @@ resource "kubernetes_secret" "sre_destination_ca_secret" {
     namespace = "orch-sre"
   }
   data = {
-    "password" = var.sre_destination_ca_secret
+    "ca.crt" = var.sre_destination_ca_secret
   }
 }
 


### PR DESCRIPTION
### Description

The keys for SRE secret created in Terraform scripts need to match the keys defined on component level as follows:
- for secret `destination-secret-url`: https://github.com/open-edge-platform/o11y-sre-exporter/blob/main/deployments/sre-exporter/values.yaml#L79
- for secret `destination-secret-ca`: https://github.com/open-edge-platform/o11y-sre-exporter/blob/main/deployments/sre-exporter/values.yaml#L71

### How Has This Been Tested?

The test needs to be run using EKS cluster.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
