### PR TITLE
Set Dependabot interval to Monthly instead of Daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     commit-message:
       prefix: "Go modules"
     reviewers:
@@ -32,7 +32,7 @@ updates:
       - "/pod-configs/module/load-balancer"
       - "/pod-configs/buckets"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     commit-message:
       prefix: "terraform"
     reviewers:
@@ -47,7 +47,7 @@ updates:
       - "/argocd/applications"
       - "/argocd/root-app"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     commit-message:
       prefix: "Helm"
     reviewers:
@@ -59,7 +59,7 @@ updates:
     directories:
       - "/installer"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     commit-message:
       prefix: "Dockerfile"
     reviewers:
@@ -70,7 +70,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     commit-message:
       prefix: "Github Actions"
     reviewers:


### PR DESCRIPTION
### Description

If we want to bulk upgrade deps, we should manually do so first instead of having Dependabot do it since it can be expensive time/cost wise.

Fixes # (issue)

To reduce CI load.

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
