### PR TITLE
Only run Contributing Guide Reminder workflow when a PR or issue is initially opened to reduce CI load

### DIFF
--- a/.github/workflows/contributing.yml
+++ b/.github/workflows/contributing.yml
@@ -4,7 +4,11 @@
 
 name: Contributing Guide Reminder
 
-on: [pull_request, issues]
+on:
+  pull_request:
+    types: [opened]
+  issues:
+    types: [opened]
 
 jobs:
   remind-contributing:


### PR DESCRIPTION
### Description

Only run Contributing Guide Reminder workflow when a PR or issue is initially opened to reduce CI load

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
