### PR TITLE
WIP: Add TLS SNI reverse proxy for exposing Orch services over a single port 🐒 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ tools/router/traefik.yml
 tools/router/docker-compose.yml
 vault-keys.json
 mage_output_file.go
+static-magefile
 fleet-secret
 *.tgz
 *.tar.gz

--- a/mage/proxy.go
+++ b/mage/proxy.go
@@ -1,0 +1,157 @@
+package mage
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// Starts a TLS reverse proxy server that exposes all Orchestrator services over a single port on the given address.
+func (Deploy) Proxy(ctx context.Context, addr string) error {
+	decodedCert, decodedKey, err := OrchTLSCertAndKey(ctx)
+	if err != nil {
+		return fmt.Errorf("get certificate and key: %w", err)
+	}
+
+	certFile, err := os.CreateTemp("", "tls-proxy-cert-")
+	if err != nil {
+		return fmt.Errorf("create certificate file: %w", err)
+	}
+	defer os.Remove(certFile.Name())
+
+	if _, err := certFile.Write(decodedCert); err != nil {
+		return fmt.Errorf("write certificate file: %w", err)
+	}
+
+	keyFile, err := os.CreateTemp("", "tls-proxy-key-")
+	if err != nil {
+		return fmt.Errorf("create key file: %w", err)
+	}
+	defer os.Remove(keyFile.Name())
+
+	if _, err := keyFile.Write(decodedKey); err != nil {
+		return fmt.Errorf("write key file: %w", err)
+	}
+
+	handler, err := NewReverseProxyHandler(
+		// TODO: Make configurable
+		map[string]string{
+			"argocd.":           "192.168.99.20",
+			"tinkerbell-nginx.": "192.168.99.40",
+			"traefik.":          "192.168.99.30",
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("create handler: %w", err)
+	}
+
+	s := &http.Server{
+		Addr:           addr,
+		Handler:        handler,
+		ReadTimeout:    15 * time.Second,
+		WriteTimeout:   15 * time.Second,
+		MaxHeaderBytes: http.DefaultMaxHeaderBytes,
+	}
+
+	fmt.Printf(
+		"Started TLS reverse proxy on https://%s using certificate %s and key %s\n",
+		addr,
+		certFile.Name(),
+		keyFile.Name(),
+	)
+
+	return s.ListenAndServeTLS(certFile.Name(), keyFile.Name())
+}
+
+// OrchTLSCertAndKey returns the Orchestrator's TLS certificate and key.
+func OrchTLSCertAndKey(ctx context.Context) ([]byte, []byte, error) {
+	kubeconfig := os.Getenv("KUBECONFIG")
+	if kubeconfig == "" {
+		return nil, nil, fmt.Errorf("KUBECONFIG environment variable is not set")
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("load Kubernetes config from KUBECONFIG: %w", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create Kubernetes client: %w", err)
+	}
+
+	secret, err := clientset.CoreV1().Secrets("orch-gateway").Get(ctx, "tls-orch", metav1.GetOptions{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get secret 'tls-orch': %w", err)
+	}
+
+	cert, certExists := secret.Data["tls.crt"]
+	key, keyExists := secret.Data["tls.key"]
+
+	if !certExists || !keyExists {
+		return nil, nil, fmt.Errorf("certificate or key not found in secret 'tls-orch'")
+	}
+
+	return cert, key, nil
+}
+
+type ReverseProxyHandler struct {
+	Routes map[string]*httputil.ReverseProxy
+}
+
+func NewReverseProxyHandler(routeIPs map[string]string) (*ReverseProxyHandler, error) {
+	routes := make(map[string]*httputil.ReverseProxy, 3)
+
+	for name, ip := range routeIPs {
+		proxy := httputil.NewSingleHostReverseProxy(
+			&url.URL{
+				Scheme: "https",
+				Host:   ip + ":443",
+			},
+		)
+
+		proxy.Transport = &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		}
+
+		routes[name] = proxy
+	}
+
+	return &ReverseProxyHandler{
+		Routes: routes,
+	}, nil
+}
+
+// ServeHTTP is the HTTP handler method for the ReverseProxyHandler struct.
+// It routes incoming HTTP requests to the appropriate backend service based on the
+// ServerName field in the TLS configuration of the request.
+func (p *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	fmt.Printf("Received request: Host=%s, ServerName=%s, URL=%s\n", r.Host, r.TLS.ServerName, r.URL)
+
+	switch {
+	case strings.HasPrefix(r.TLS.ServerName, "argocd."):
+		fmt.Printf("Routing to argocd backend\n")
+		p.Routes["argocd."].ServeHTTP(w, r)
+
+	case strings.HasPrefix(r.TLS.ServerName, "tinkerbell-nginx."):
+		fmt.Printf("Routing to tinkerbell-nginx backend\n")
+		p.Routes["tinkerbell-nginx."].ServeHTTP(w, r)
+
+	default:
+		fmt.Printf("Routing to traefik backend\n")
+		p.Routes["traefik."].ServeHTTP(w, r)
+	}
+}

--- a/terraform/edge-network/main.tf
+++ b/terraform/edge-network/main.tf
@@ -9,7 +9,7 @@ resource "libvirt_network" "edge_network" {
 
   autostart = true
 
-  domain = var.network_domain
+  domain = var.dns_domain
 
   addresses = var.network_subnet_cidrs
 
@@ -28,7 +28,7 @@ resource "libvirt_network" "edge_network" {
     dynamic "hosts" {
       for_each = var.dns_hosts
       content {
-        hostname = hosts.value.hostname
+        hostname = "${hosts.value.hostname}.${var.dns_domain}"
         ip       = hosts.value.ip
       }
     }
@@ -43,7 +43,7 @@ resource "libvirt_network" "edge_network" {
     // Do not forward DNS queries for the local network domain
     options {
       option_name  = "local"
-      option_value = "/${var.network_domain}/"
+      option_value = "/${var.dns_domain}/"
     }
 
     // Forward queries to the configured DNS resolvers if the local domain is not matched
@@ -80,7 +80,7 @@ resource "libvirt_network" "edge_network" {
     }
     options {
       option_name  = "dhcp-boot"
-      option_value = var.dhcp_boot
+      option_value = "tag:efi-http,https://tinkerbell-nginx.${var.dns_domain}/tink-stack/signed_ipxe.efi"
     }
   }
 }

--- a/terraform/edge-network/variables.tf
+++ b/terraform/edge-network/variables.tf
@@ -26,16 +26,18 @@ variable "network_bridge" {
   default     = "virbr1"
 }
 
-variable "network_domain" {
-  type        = string
-  description = "The domain of the network"
-  default     = "cluster.onprem"
-}
-
 variable "network_subnet_cidrs" {
   type        = list(string)
   description = "The CIDRs of the network"
   default     = ["192.168.99.0/24"]
+}
+
+variable "dns_domain" {
+  type        = string
+  description = "The DNS domain"
+  # TODO: Change this to the correct domain name
+  # default     = "cluster.onprem"
+  default     = "demo.onprem.espdqa.infra-host.com"
 }
 
 variable "dns_hosts" {
@@ -45,46 +47,39 @@ variable "dns_hosts" {
   }))
   description = "The list of DNS hosts"
   default = [
-    { hostname = "alerting-monitor.cluster.onprem", ip = "192.168.99.30" },
-    { hostname = "api.cluster.onprem", ip = "192.168.99.30" },
-    { hostname = "app-orch.cluster.onprem", ip = "192.168.99.30" },
-    { hostname = "app-service-proxy.cluster.onprem", ip = "192.168.99.30" },
-    { hostname = "argocd.cluster.onprem", ip = "192.168.99.20" },
-    { hostname = "attest-node.cluster.onprem", ip = "192.168.99.30" },
-    { hostname = "cluster-orch-edge-node.cluster.onprem", ip = "192.168.99.30" },
-    { hostname = "cluster-orch-node.cluster.onprem", ip = "192.168.99.30" },
-    { hostname = "cluster.onprem", ip = "192.168.99.30" },
-    { hostname = "connect-gateway.cluster.onprem", ip = "192.168.99.30" },
-    { hostname = "fleet.cluster.onprem", ip = "192.168.99.30" },
-    { hostname = "infra-node.cluster.onprem", ip = "192.168.99.30" },
-    { hostname = "keycloak.cluster.onprem", ip = "192.168.99.30" },
-    { hostname = "license-node.cluster.onprem", ip = "192.168.99.30" },
-    { hostname = "log-query.cluster.onprem", ip = "192.168.99.30" },
-    { hostname = "logs-node.cluster.onprem", ip = "192.168.99.30" },
-    { hostname = "metadata.cluster.onprem", ip = "192.168.99.30" },
-    { hostname = "metrics-node.cluster.onprem", ip = "192.168.99.30" },
-    { hostname = "observability-admin.cluster.onprem", ip = "192.168.99.30" },
-    { hostname = "observability-ui.cluster.onprem", ip = "192.168.99.30" },
-    { hostname = "onboarding-node.cluster.onprem", ip = "192.168.99.30" },
-    { hostname = "onboarding-stream.cluster.onprem", ip = "192.168.99.30" },
-    { hostname = "registry-oci.cluster.onprem", ip = "192.168.99.30" },
-    { hostname = "registry.cluster.onprem", ip = "192.168.99.30" },
-    { hostname = "release.cluster.onprem", ip = "192.168.99.30" },
-    { hostname = "telemetry-node.cluster.onprem", ip = "192.168.99.30" },
-    { hostname = "tinkerbell-nginx.cluster.onprem", ip = "192.168.99.40" },
-    { hostname = "tinkerbell-server.cluster.onprem", ip = "192.168.99.30" },
-    { hostname = "update-node.cluster.onprem", ip = "192.168.99.30" },
-    { hostname = "vault.cluster.onprem", ip = "192.168.99.30" },
-    { hostname = "vnc.cluster.onprem", ip = "192.168.99.30" },
-    { hostname = "web-ui.cluster.onprem", ip = "192.168.99.30" },
-    { hostname = "ws-app-service-proxy.cluster.onprem", ip = "192.168.99.30" },
+    { hostname = "alerting-monitor", ip = "192.168.99.30" },
+    { hostname = "api", ip = "192.168.99.30" },
+    { hostname = "app-orch", ip = "192.168.99.30" },
+    { hostname = "app-service-proxy", ip = "192.168.99.30" },
+    { hostname = "argocd", ip = "192.168.99.20" },
+    { hostname = "attest-node", ip = "192.168.99.30" },
+    { hostname = "cluster-orch-edge-node", ip = "192.168.99.30" },
+    { hostname = "cluster-orch-node", ip = "192.168.99.30" },
+    { hostname = "connect-gateway", ip = "192.168.99.30" },
+    { hostname = "fleet", ip = "192.168.99.30" },
+    { hostname = "infra-node", ip = "192.168.99.30" },
+    { hostname = "keycloak", ip = "192.168.99.30" },
+    { hostname = "license-node", ip = "192.168.99.30" },
+    { hostname = "log-query", ip = "192.168.99.30" },
+    { hostname = "logs-node", ip = "192.168.99.30" },
+    { hostname = "metadata", ip = "192.168.99.30" },
+    { hostname = "metrics-node", ip = "192.168.99.30" },
+    { hostname = "observability-admin", ip = "192.168.99.30" },
+    { hostname = "observability-ui", ip = "192.168.99.30" },
+    { hostname = "onboarding-node", ip = "192.168.99.30" },
+    { hostname = "onboarding-stream", ip = "192.168.99.30" },
+    { hostname = "registry-oci", ip = "192.168.99.30" },
+    { hostname = "registry", ip = "192.168.99.30" },
+    { hostname = "release", ip = "192.168.99.30" },
+    { hostname = "telemetry-node", ip = "192.168.99.30" },
+    { hostname = "tinkerbell-nginx", ip = "192.168.99.40" },
+    { hostname = "tinkerbell-server", ip = "192.168.99.30" },
+    { hostname = "update-node", ip = "192.168.99.30" },
+    { hostname = "vault", ip = "192.168.99.30" },
+    { hostname = "vnc", ip = "192.168.99.30" },
+    { hostname = "web-ui", ip = "192.168.99.30" },
+    { hostname = "ws-app-service-proxy", ip = "192.168.99.30" },
   ]
-}
-
-variable "dhcp_boot" {
-  type        = string
-  description = "The DHCP boot option"
-  default     = "tag:efi-http,https://tinkerbell-nginx.cluster.onprem/tink-stack/signed_ipxe.efi"
 }
 
 variable "dns_resolvers" {


### PR DESCRIPTION
### Description

Pure Go stdlib implementation of a TLS SNI-aware reverse proxy the exposes all Orchestrator services on a single network address (IP:443). This enables the ability to allow Edge Nodes or Admins to reach Argo, Web-UI, Tinkerbell-Nginx, and more via a single address like **10.0.0.10:443** (all DNS records should be pointed at this address) 🚀 

This feature is required to expose Orchestrator service deployed in a Development environment so they can onboard Edge Nodes (bare metal or virtual) to it.

Tested with On-Prem Orchestrator. Intended to replace the `Router mg.Namespace` used for KinD Orchestrator.

#### Demo

```shell
# After deploying Orchestrator, start the proxy with elevated permissions to bind to host port 443
orch-host $ mage -compile ./static-magefile
orch-host $ sudo setcap CAP_NET_BIND_SERVICE=+ep static-magefile
orch-host $ ./static-magefile deploy:proxy 10.23.21.76:443

Started TLS reverse proxy on https://10.23.21.76:443 using certificate /tmp/proxy-cert-327356196 and key /tmp/proxy-key-1004308606

# On an external host, access some services
external-host $ curl -k https://argocd.demo.onprem.espdqa.infra-host.com

<!doctype html><html lang="en"><head><meta charset="UTF-8"><title>Argo CD</title><base href="/"><meta name="viewport" content="width=device-width,initial-scale=1"><link rel="icon" type="image/png" href="assets/favicon/favicon-32x32.png" sizes="32x32"/><link rel="icon" type="image/png" href="assets/favicon/favicon-16x16.png" sizes="16x16"/><link href="assets/fonts.css" rel="stylesheet"><script defer="defer" src="main.188fbc4df0d91321b0ba.js"></script></head><body><noscript><p>Your browser does not support JavaScript. Please enable JavaScript to view the site. Alternatively, Argo CD can be used with the <a href="https://argoproj.github.io/argo-cd/cli_installation/">Argo CD CLI</a>.</p></noscript><div id="app"></div></body><script defer="defer" src="extensions.js"></script></html>

external-host $ curl -k https://web-ui.demo.onprem.espdqa.infra-host.com

<!doctype html><html lang="en" data-theme-colors="tb"><head><meta charset="UTF-8"/><link rel="icon" href="assets/favicon.png"/><meta http-equiv="X-UA-Compatible" content="IE=edge"/><meta name="viewport" content="width=device-width,initial-scale=1"/><title>Edge Orchestrator</title><script src="/runtime-config.js"></script><script defer="defer" src="/main.bc4925dc49e828aaa6c9.js"></script></head><body><div id="root"></div></body></html>

# See the logs of the proxy process showing successful proxying of requests to upstreams
orch-host $ ./static-magefile deploy:proxy 10.23.21.76:443

Started TLS reverse proxy on https://10.23.21.76:443 using certificate /tmp/proxy-cert-327356196 and key /tmp/proxy-key-1004308606
Received request: Host=argocd.demo.onprem.espdqa.infra-host.com, ServerName=argocd.demo.onprem.espdqa.infra-host.com, URL=/
Received request: Host=web-ui.demo.onprem.espdqa.infra-host.com, ServerName=web-ui.demo.onprem.espdqa.infra-host.com, URL=/
```

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
