### PR TITLE
Update Squid ACL

### DIFF
--- a/argocd/applications/configs/squid-proxy.yaml
+++ b/argocd/applications/configs/squid-proxy.yaml
@@ -24,7 +24,7 @@ allowedDomains: >
   .cloudfront.net
   .api.snapcraft.io
 
-sentinelDomains: ".sentinelcloud.com"
+sentinelDomains:
 
 aptDomains: >
   .archive.ubuntu.com
@@ -37,5 +37,6 @@ aptDomains: >
   .archive.canonical.com
   .extras.ubuntu.com
   changelogs.ubuntu.com
+  cloud-images.ubuntu.com
 
 debianDomains: ".debian.org cdn.debian.net http.debian.net "


### PR DESCRIPTION
### Description

Update ACL for Squid proxy deployment to add one new URL and remove on as well.

https://jira.devtools.intel.com/browse/ITEP-26569
https://jira.devtools.intel.com/browse/ITEP-26696

Fixes # (issue)

### Any Newly Introduced Dependencies

N/A

### How Has This Been Tested?

On-prem deployment using Squid proxy found the following in Squid logs during EN onboarding using Ubuntu OS:

```
1744644393.673      0 127.0.0.6 TCP_DENIED/403 1992 CONNECT cloud-images.ubuntu.com:443 - HIER_NONE/- text/html
```

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
