### PR TITLE
add missing acl for Squid proxy

### DIFF
--- a/argocd/applications/configs/squid-proxy.yaml
+++ b/argocd/applications/configs/squid-proxy.yaml
@@ -23,6 +23,7 @@ allowedDomains: >
   .public.ecr.aws
   .cloudfront.net
   .api.snapcraft.io
+  .rke2.io
 
 sentinelDomains:
 


### PR DESCRIPTION
### Description

Edge Node cluster creation is failing when using Squid proxy.  This PR adds a new URL to Squid ACL.

https://jira.devtools.intel.com/browse/ITEP-26884

Fixes # (issue)

### Any Newly Introduced Dependencies

N/A

### How Has This Been Tested?

Manual Onboarding Test using microvisor OS.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
