### PR TITLE
Downsize On-Prem CI runner to reduce costs

### DIFF
--- a/.github/workflows/virtual-integration.yml
+++ b/.github/workflows/virtual-integration.yml
@@ -681,7 +681,7 @@ jobs:
       github.ref == 'refs/heads/main' ||
       github.ref == 'refs/heads/main-pass-validation'
       )
-    runs-on: ubuntu-22.04-32core-128GB
+    runs-on: ubuntu-24.04-16core-64GB
     timeout-minutes: 120
     env:
       KUBECONFIG: ${{ github.workspace }}/terraform/orchestrator/files/kubeconfig

--- a/.github/workflows/virtual-integration.yml
+++ b/.github/workflows/virtual-integration.yml
@@ -704,8 +704,8 @@ jobs:
           TF_VAR_intel_release_service_refresh_token: value-not-used
           TF_VAR_deploy_tag: ${{ needs.build-publish.outputs.deb-version }}
           TF_VAR_FILE: ${{ github.workspace }}/terraform/orchestrator/terraform.tfvars
-          TF_VAR_vm_vcpu: 24
-          TF_VAR_vm_memory: 65536
+          TF_VAR_vm_vcpu: 16
+          TF_VAR_vm_memory: 49152
           TF_VAR_docker_username: ${{ secrets.SYS_DOCKERHUB_USERNAME }}
           TF_VAR_docker_password: ${{ secrets.SYS_DOCKERHUB_RO }}
         timeout-minutes: 90


### PR DESCRIPTION
### Description

Downsizes the CI runner for the On-Prem job from `ubuntu-22.04-32core-128GB` to `ubuntu-24.04-16core-64GB` to reduce 💵

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
