### PR TITLE
bump RKE2 Provider to v0.14.0

### DIFF
--- a/argocd/applications/custom/capi-operator.tpl
+++ b/argocd/applications/custom/capi-operator.tpl
@@ -2,9 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-core: cluster-api:v1.9.0
-bootstrap: capr-system:rke2:v0.12.0
-controlPlane: capr-system:rke2:v0.12.0
+core: cluster-api:v1.9.7
+bootstrap: capr-system:rke2:v0.14.0
+controlPlane: capr-system:rke2:v0.14.0
 env:
   manager:
   {{- if .Values.argo.proxy }}


### PR DESCRIPTION
### Description

Bump RKE2 Provider version to v0.14.0.  Also bump the Cluster API core to v1.9.7.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
