### PR TITLE
Fix on-prem artifact tag discrepancy 

### DIFF
--- a/on-prem-installers/mage/Magefile.go
+++ b/on-prem-installers/mage/Magefile.go
@@ -271,7 +271,7 @@ func (Publish) DEBPackages(ctx context.Context) error {
 		if branchName == "main" ||
 			strings.Contains(branchName, "pass-validation") ||
 			strings.HasPrefix(branchName, "release") {
-			tags = fmt.Sprintf("%s,latest-%s", version, branchName)
+			tags = fmt.Sprintf("%s,latest-%s-dev", version, branchName)
 			artifactName = fmt.Sprintf("%s/%s:%s", OpenEdgePlatformFilesRegistry, name, tags)
 		}
 
@@ -334,7 +334,7 @@ func (Publish) Files(ctx context.Context) error {
 	if branchName == "main" ||
 		strings.Contains(branchName, "pass-validation") ||
 		strings.HasPrefix(branchName, "release") {
-		tags = fmt.Sprintf("%s,latest-%s", version, branchName)
+		tags = fmt.Sprintf("%s,latest-%s-dev", version, branchName)
 		artifactName = fmt.Sprintf("%s/on-prem:%s", OpenEdgePlatformFilesRegistry, tags)
 	}
 

--- a/terraform/orchestrator/terraform.tfvars
+++ b/terraform/orchestrator/terraform.tfvars
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Set your own custom values here and uncomment so you don't need to enter them everytime you run terraform apply
-# deploy_tag = "latest-main"
+# deploy_tag = "latest-main-dev"
 
 # Set the following to true to deploy orchestrator from locally built artifacts
 # use_local_build_artifact = false

--- a/terraform/orchestrator/variables.tf
+++ b/terraform/orchestrator/variables.tf
@@ -161,7 +161,7 @@ variable "enable_auto_install" {
 variable "deploy_tag" {
   type        = string
   description = "Orchestrator release tag version. If empty, will use the default main branch tag."
-  default     = "latest-main"
+  default     = "latest-main-dev"
 }
 
 variable "use_local_build_artifact" {


### PR DESCRIPTION
### Description

- Keep artifact tags consistent for on-prem installers and repo archives
- Revert #222 to use `latest-main-dev` as default tag for onprem deploy function

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
