### PR TITLE
no verbose on orchCA

### DIFF
--- a/mage/generate.go
+++ b/mage/generate.go
@@ -1619,8 +1619,7 @@ export filepath to REQUESTS_CA_BUNDLE if using for robot framework test with sta
 // OrchCA Saves Orchestrators's CA certificate to `orch-ca.crt` so it can be imported to trust store for web access.
 func (Gen) orchCA(filePath string) error {
 	var certKey string
-	kubeCmd := fmt.Sprintf("kubectl --v=%d get secret -n orch-gateway tls-orch -o json",
-		verboseLevel)
+	kubeCmd := fmt.Sprintf("kubectl get secret -n orch-gateway tls-orch -o json")
 
 	data, err := script.NewPipe().Exec(kubeCmd).String()
 	if err != nil {


### PR DESCRIPTION
### Description

Seeing warnings(?) get printed out during the kubectl command in `mage gen:orchCA`  which can ultimately lead to the error below when trying to parse it as JSON:

```
ubuntu@coder-zano-on-prem-217714:~/emf$ mage gen:orchCA
Error: check JSON for certificate: invalid character 'I' looking for beginning of value
ubuntu@coder-zano-on-prem-217714:~/emf$ kubectl --v=1 get secret -n orch-gateway tls-orch -o json
I0425 21:52:35.838681   49628 envvar.go:172] "Feature gate default state" feature="ClientsPreferCBOR" enabled=false
I0425 21:52:35.838797   49628 envvar.go:172] "Feature gate default state" feature="InformerResourceVersion" enabled=false
I0425 21:52:35.838806   49628 envvar.go:172] "Feature gate default state" feature="InOrderInformers" enabled=true
I0425 21:52:35.838813   49628 envvar.go:172] "Feature gate default state" feature="WatchListClient" enabled=false
I0425 21:52:35.838819   49628 envvar.go:172] "Feature gate default state" feature="ClientsAllowCBOR" enabled=false
{
    "apiVersion": "v1",
    "data": {
        "ca.crt": "LS0tLS1CRUdJTiBDRVJUSUZJ
```

This happens from the `verboseLevel` defaulting to 1 , if set to 0 or removing the `--v=%d` all goes well
```
	kubeCmd := fmt.Sprintf("kubectl --v=%d get secret -n orch-gateway tls-orch -o json",
		verboseLevel)

	data, err := script.NewPipe().Exec(kubeCmd).String()
```

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
