### PR TITLE
upgrade for postgres

### DIFF
--- a/argocd/applications/configs/postgresql.yaml
+++ b/argocd/applications/configs/postgresql.yaml
@@ -10,3 +10,6 @@ primary:
       drop: ["ALL"]
     seccompProfile:
       type: "RuntimeDefault"
+
+auth:
+  existingSecret: postgresql


### PR DESCRIPTION
early stages. for an upgrade of postgres we need to stop the helm chart from controlling the password. as we need to restore the old password from before the update. this means that we will also need to generate the password in our scripts, like we do in keycloak