### PR TITLE
Change OTEL `config` to `alternateConfig` - update edgenode and orchestrator observability

### DIFF
--- a/argocd/applications/configs/edgenode-observability.yaml
+++ b/argocd/applications/configs/edgenode-observability.yaml
@@ -20,7 +20,7 @@ mimir-distributed:
       exitCommand: ""
 
 opentelemetry-collector:
-  config:
+  alternateConfig:
     receivers:
       otlp:
         protocols:

--- a/argocd/applications/configs/orchestrator-observability.yaml
+++ b/argocd/applications/configs/orchestrator-observability.yaml
@@ -20,7 +20,7 @@ mimir-distributed:
       exitCommand: ""
 
 opentelemetry-collector:
-  config:
+  alternateConfig:
     receivers:
       otlp:
         protocols:
@@ -35,7 +35,7 @@ opentelemetry-collector:
         sampling_percentage: 50
 
 opentelemetry-collector-daemonset:
-  config:
+  alternateConfig:
     receivers:
       otlp:
         protocols:

--- a/argocd/applications/custom/edgenode-observability.tpl
+++ b/argocd/applications/custom/edgenode-observability.tpl
@@ -712,7 +712,7 @@ opentelemetry-collector:
   {{- with .Values.argo.imagePullSecrets }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  config:
+  alternateConfig:
     service:
       pipelines:
         metrics:

--- a/argocd/applications/templates/edgenode-observability.yaml
+++ b/argocd/applications/templates/edgenode-observability.yaml
@@ -19,7 +19,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: o11y/charts/{{$appName}}
-      targetRevision: 0.10.0
+      targetRevision: 0.10.1
       helm:
         releaseName: {{$appName}}
         valuesObject:

--- a/argocd/applications/templates/orchestrator-observability.yaml
+++ b/argocd/applications/templates/orchestrator-observability.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: o11y/charts/{{$appName}}
-      targetRevision: 0.5.1
+      targetRevision: 0.5.2
       helm:
         releaseName: {{$appName}}
         valuesObject:


### PR DESCRIPTION
### Description

Changes opentelemetry collector `config` to `alternateConfig`.
Updates:
- edgenode-observability to `0.10.1`
- orchestrator-observability to `0.5.2`

Related PR (needs to be merged after):
- https://github.com/open-edge-platform/o11y-charts/pull/34

### Any Newly Introduced Dependencies

N/A

### How Has This Been Tested?

Tested on local kind orchestrator deployment.

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
