### PR TITLE
Disable interactive mode when installing libvirt

### DIFF
--- a/tools/setup-libvirt.bash
+++ b/tools/setup-libvirt.bash
@@ -8,9 +8,9 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-sudo apt-get update -y
+sudo NEEDRESTART_MODE=a DEBIAN_FRONTEND=noninteractive apt-get update -y
 
-sudo apt-get -y install \
+sudo NEEDRESTART_MODE=a DEBIAN_FRONTEND=noninteractive apt-get -y install \
     libvirt-daemon-system \
     libvirt-clients \
     qemu-kvm \


### PR DESCRIPTION
### Description

When deploying onprem using libvirt, a number of artifacts need to be installed before proceeding with the deployment. When installation is started, it is started in interactive mode. The proposed change in this PR is to make this non-interactive to avoid requiring further user input.

### Any Newly Introduced Dependencies

N/A

### How Has This Been Tested?

Locally.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
