### PR TITLE
ITEP-62003 bump ADM and App Catalog to support Geti 2.9.0

### DIFF
--- a/argocd/applications/templates/app-deployment-manager.yaml
+++ b/argocd/applications/templates/app-deployment-manager.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: app/charts/{{$appName}}
-      targetRevision: 2.3.44
+      targetRevision: 2.3.45
       helm:
         releaseName: {{$appName}}
         valuesObject:

--- a/argocd/applications/templates/app-orch-catalog.yaml
+++ b/argocd/applications/templates/app-orch-catalog.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: app/charts/{{$appName}}
-      targetRevision: 0.11.33
+      targetRevision: 0.11.34
       helm:
         releaseName: {{ $appName }}
         valuesObject:


### PR DESCRIPTION
### Description

Bumping App Catalog to 0.11.34 and ADM to 2.3.45 so that they can support extra types of `ignoredResources` in the Application.

Geti uses a new version of Flyte that modifies the initContainers of Deployments and Jobs after it has been deployed by Helm. Fleet does not like things being modified, so we have to tell it to ignore changes in certain resources.

Fixes # ITEP-62003

### Any Newly Introduced Dependencies

No

### How Has This Been Tested?

**Still being tested - do not merge**

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes
- [X] I have not introduced any 3rd party dependency changes
- [X] I have performed a self-review of my code
