### PR TITLE
feat: enable-kube-apiserver-metrics profile

### DIFF
--- a/argocd/applications/custom/orchestrator-prometheus-agent.tpl
+++ b/argocd/applications/custom/orchestrator-prometheus-agent.tpl
@@ -21,3 +21,8 @@ prometheus:
     resources:
       {{- toYaml . | nindent 6 }}
 {{- end }}
+
+{{- if (index .Values.argo.enabled kube-apiserver-metrics) }}
+kubeApiServer:
+  enabled: true
+{{- end }}

--- a/orch-configs/profiles/enable-kube-apiserver-metrics.yaml
+++ b/orch-configs/profiles/enable-kube-apiserver-metrics.yaml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+argo:
+  enabled:
+    kube-apiserver-metrics: true


### PR DESCRIPTION
### Description

Introduced profile that enables metrics for kube-apiserver. 
Profile can be applied to some clusters, so no environments have to have it.

### Any Newly Introduced Dependencies
none. 

### How Has This Been Tested?
TODO

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
