### PR TITLE
Upgrade fleet to 0.12.2

### DIFF
--- a/argocd/applications/templates/app-deployment-crd.yaml
+++ b/argocd/applications/templates/app-deployment-crd.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: app/charts/{{$appName}}
-      targetRevision: 2.3.44
+      targetRevision: 2.4.7
       helm:
         releaseName: {{$appName}}
         valuesObject:

--- a/argocd/applications/templates/app-deployment-manager.yaml
+++ b/argocd/applications/templates/app-deployment-manager.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: app/charts/{{$appName}}
-      targetRevision: 2.3.44
+      targetRevision: 2.4.7
       helm:
         releaseName: {{$appName}}
         valuesObject:

--- a/argocd/applications/templates/app-orch-catalog.yaml
+++ b/argocd/applications/templates/app-orch-catalog.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: app/charts/{{$appName}}
-      targetRevision: 0.11.33
+      targetRevision: 0.14.1
       helm:
         releaseName: {{ $appName }}
         valuesObject:

--- a/argocd/applications/templates/app-orch-tenant-controller.yaml
+++ b/argocd/applications/templates/app-orch-tenant-controller.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: app/charts/{{$appName}}
-targetRevision: 0.3.2
+      targetRevision: 0.3.2
       helm:
         releaseName: {{$appName}}
         valuesObject:

--- a/argocd/applications/templates/app-orch-tenant-controller.yaml
+++ b/argocd/applications/templates/app-orch-tenant-controller.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: app/charts/{{$appName}}
-      targetRevision: 0.2.13
+targetRevision: 0.3.2
       helm:
         releaseName: {{$appName}}
         valuesObject:

--- a/argocd/applications/templates/fleet-controller.yaml
+++ b/argocd/applications/templates/fleet-controller.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: https://rancher.github.io/fleet-helm-charts/
       chart: fleet
-      targetRevision: 0.10.2
+      targetRevision: 0.12.2
       helm:
         releaseName: {{ $appName }}
         valuesObject:

--- a/argocd/applications/templates/fleet-crd.yaml
+++ b/argocd/applications/templates/fleet-crd.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: https://rancher.github.io/fleet-helm-charts/
       chart: fleet-crd
-      targetRevision: 0.10.2
+      targetRevision: 0.12.2
       helm:
         releaseName: {{ $appName }}
         valuesObject:

--- a/mage/edge_cluster.go
+++ b/mage/edge_cluster.go
@@ -18,7 +18,6 @@ import (
 	"github.com/bitfield/script"
 
 	"github.com/open-edge-platform/edge-manageability-framework/internal/retry"
-	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -197,7 +196,7 @@ func waitForENFleetAgentReady() error {
 	// Since kubeconfig context is Edge Cluster
 	edgeClusterPodStatusCmd := "kubectl get pods -A"
 
-	cmd := "kubectl -n cattle-fleet-system get pods fleet-agent-0 -o jsonpath='{.status.phase}'"
+	cmd := "kubectl -n cattle-fleet-system get pods -l app=fleet-agent -o jsonpath='{.items[0].status.phase}'"
 
 	fmt.Printf("Waiting %v minutes for EN Fleet Agent to start...\n", waitForReadyMin)
 	fn := func() error {

--- a/mage/edge_cluster.go
+++ b/mage/edge_cluster.go
@@ -10,6 +10,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"gopkg.in/yaml.v3"
 	"net/http"
 	"os/exec"
 	"strings"

--- a/mage/edge_cluster.go
+++ b/mage/edge_cluster.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/bitfield/script"
-
 	"github.com/open-edge-platform/edge-manageability-framework/internal/retry"
 )
 
@@ -195,7 +194,6 @@ func waitForENFleetAgentReady() error {
 
 	// Since kubeconfig context is Edge Cluster
 	edgeClusterPodStatusCmd := "kubectl get pods -A"
-
 	cmd := "kubectl -n cattle-fleet-system get pods -l app=fleet-agent -o jsonpath='{.items[0].status.phase}'"
 
 	fmt.Printf("Waiting %v minutes for EN Fleet Agent to start...\n", waitForReadyMin)

--- a/mage/edge_cluster.go
+++ b/mage/edge_cluster.go
@@ -10,11 +10,12 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"gopkg.in/yaml.v3"
 	"net/http"
 	"os/exec"
 	"strings"
 	"time"
+
+	"gopkg.in/yaml.v3"
 
 	"github.com/bitfield/script"
 	"github.com/open-edge-platform/edge-manageability-framework/internal/retry"


### PR DESCRIPTION
### Description

This PR upgrades Fleet to version 0.12.2 and ADM to version 2.4.7, which uses the new Fleet API accordingly. (https://github.com/open-edge-platform/app-orch-deployment/pull/62) 

This PR also upgrades app-orch-tenant-controller to version 0.3.2
This PR also upgrades app-orch-catalog to version 0.14.1

Fixes # (issue)

### Any Newly Introduced Dependencies
No new dependencies. Fleet is upgraded to 0.12.2 

### How Has This Been Tested?

This change was tested using EnIC and ADM component tests. Additionally, it was tested using a stress test to verify that extensions can be deployed without any problems. 

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
