### PR TITLE
ITEP-62003 update ADM and App Catalog versions

### DIFF
--- a/argocd/applications/templates/app-deployment-manager.yaml
+++ b/argocd/applications/templates/app-deployment-manager.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: app/charts/{{$appName}}
-      targetRevision: 2.3.44
+      targetRevision: 2.4.7
       helm:
         releaseName: {{$appName}}
         valuesObject:

--- a/argocd/applications/templates/app-orch-catalog.yaml
+++ b/argocd/applications/templates/app-orch-catalog.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: app/charts/{{$appName}}
-      targetRevision: 0.11.33
+      targetRevision: 0.14.1
       helm:
         releaseName: {{ $appName }}
         valuesObject:


### PR DESCRIPTION
### Description

ADM and App Catalog had problems handling the `ignoredResources` keyword for the types `Job` and `Deployment`. Version 2.9.0 of Geti (Flyte) modifies these entities from what is in the helm chart, and so deployment by Fleet requires the ignoring of certain instances of Job and Deployment, so that the deployment can complete.

Fixes # ITEP-62003

### Any Newly Introduced Dependencies

None

### How Has This Been Tested?

Deployed through coder and tested in Component tests

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes
- [X] I have not introduced any 3rd party dependency changes
- [X] I have performed a self-review of my code
