### PR TITLE
Increase timeout during e2e to allow for service component creation

### DIFF
--- a/e2e-tests/orchestrator/orchestrator_test.go
+++ b/e2e-tests/orchestrator/orchestrator_test.go
@@ -1207,7 +1207,7 @@ func setupNewService(port, serviceName, namespace, serviceType string) error {
 		return err
 	}
 
-	timeout := 32 * time.Second
+	timeout := 120 * time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 

--- a/mage/deploy.go
+++ b/mage/deploy.go
@@ -1030,7 +1030,7 @@ func createOrUpdateGiteaAccount(username string, password string) error {
 // Get the Gitea credentials from the Kubernetes secret argocd-gitea-credential in orch-platform namespace
 func (Deploy) getArgoGiteaCredentials() (string, string, error) {
 	// Load the username from the Kubernetes secret argocd-gitea-credential in orch-platform namespace
-	cmd := "kubectl get secret argocd-gitea-credential -n orch-platform -o jsonpath='{.data.username}'"
+	cmd := "kubectl get secret argocd-gitea-credential -n gitea -o jsonpath='{.data.username}'"
 	encodedUsername, err := script.Exec(cmd).String()
 	if err != nil {
 		return "", "", fmt.Errorf("error retrieving username from Kubernetes secret: %w", err)
@@ -1038,7 +1038,7 @@ func (Deploy) getArgoGiteaCredentials() (string, string, error) {
 	argoGiteaUsername := strings.TrimSpace(encodedUsername)
 
 	// Load the password from the Kubernetes secret argocd-gitea-credential in orch-platform namespace
-	cmd = "kubectl get secret argocd-gitea-credential -n orch-platform -o jsonpath='{.data.password}'"
+	cmd = "kubectl get secret argocd-gitea-credential -n gitea -o jsonpath='{.data.password}'"
 	encodedPassword, err := script.Exec(cmd).String()
 	if err != nil {
 		return "", "", fmt.Errorf("error retrieving password from Kubernetes secret: %w", err)

--- a/mage/deploy.go
+++ b/mage/deploy.go
@@ -1030,7 +1030,7 @@ func createOrUpdateGiteaAccount(username string, password string) error {
 // Get the Gitea credentials from the Kubernetes secret argocd-gitea-credential in orch-platform namespace
 func (Deploy) getArgoGiteaCredentials() (string, string, error) {
 	// Load the username from the Kubernetes secret argocd-gitea-credential in orch-platform namespace
-	cmd := "kubectl get secret argocd-gitea-credential -n gitea -o jsonpath='{.data.username}'"
+	cmd := "kubectl get secret argocd-gitea-credential -n orch-platform -o jsonpath='{.data.username}'"
 	encodedUsername, err := script.Exec(cmd).String()
 	if err != nil {
 		return "", "", fmt.Errorf("error retrieving username from Kubernetes secret: %w", err)
@@ -1038,7 +1038,7 @@ func (Deploy) getArgoGiteaCredentials() (string, string, error) {
 	argoGiteaUsername := strings.TrimSpace(encodedUsername)
 
 	// Load the password from the Kubernetes secret argocd-gitea-credential in orch-platform namespace
-	cmd = "kubectl get secret argocd-gitea-credential -n gitea -o jsonpath='{.data.password}'"
+	cmd = "kubectl get secret argocd-gitea-credential -n orch-platform -o jsonpath='{.data.password}'"
 	encodedPassword, err := script.Exec(cmd).String()
 	if err != nil {
 		return "", "", fmt.Errorf("error retrieving password from Kubernetes secret: %w", err)


### PR DESCRIPTION
### Description

Increase timeout to allow for setting up service component during e2e tests.

### Any Newly Introduced Dependencies

N/A

### How Has This Been Tested?

On CI

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
