### PR TITLE
update tenant-controller to 0.3.5 and manifest to 1.1.2

### DIFF
--- a/argocd/applications/custom/app-orch-tenant-controller.tpl
+++ b/argocd/applications/custom/app-orch-tenant-controller.tpl
@@ -28,7 +28,7 @@ configProvisioner:
   releaseServiceRootUrl: oci://{{ .Values.argo.releaseService.ociRegistry }}
   {{- end}}
 
-  manifestTag: "v1.0.36"
+  manifestTag: "v1.1.2"
 
   # http proxy settings
   {{- if .Values.argo.proxy.httpProxy}}

--- a/argocd/applications/templates/app-orch-tenant-controller.yaml
+++ b/argocd/applications/templates/app-orch-tenant-controller.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: app/charts/{{$appName}}
-      targetRevision: 0.3.2
+      targetRevision: 0.3.5
       helm:
         releaseName: {{$appName}}
         valuesObject:


### PR DESCRIPTION
### Description

Updates manifest to use a new version of kubevirt-helper that does not use edge node release proxy. Updates app-orch-tenant-controller with additional validations.

### How Has This Been Tested?

Tested deployment of virtualization extension. App-orch-tenant controller was a validation, unit testing, and fuzz testing update, and does not affect runtime behavior.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
