### PR TITLE
ITEP-67065 bump Tenant Controller and ASP

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,13 +26,13 @@
 /on-prem-installers/ @se-chris-thach @palade john.oloughlin@intel.com gary.loughnane@intel.com @emmakenny @PalashGoelIntel @mdbalvin @ashridatta @sys-orch-approve
 
 # application catalog tests
-/e2e-tests/orchestrator/app_catalog_test.go @scottmbaker @ray-milkey @adibrastegarnia @malruben @SeanCondon @sys-orch-approve
-/e2e-tests/orchestrator/catalog_bootstrap_test.go @scottmbaker @ray-milkey @adibrastegarnia @malruben @SeanCondon @sys-orch-approve
+/e2e-tests/orchestrator/app_catalog_test.go @scottmbaker @adibrastegarnia @SeanCondon @badhrinathpa @pudelkoM @guptagunjan @sys-orch-approve
+/e2e-tests/orchestrator/catalog_bootstrap_test.go @scottmbaker @adibrastegarnia @SeanCondon @badhrinathpa @pudelkoM @guptagunjan @sys-orch-approve
 
 # app orch templates and values
-/argocd/applications/templates/app* @scottmbaker @ray-milkey @adibrastegarnia @malruben @SeanCondon @sys-orch-approve
-/argocd/applications/configs/app* @scottmbaker @ray-milkey @adibrastegarnia @malruben @SeanCondon @sys-orch-approve
-/argocd/applications/custom/app* @scottmbaker @ray-milkey @adibrastegarnia @malruben @SeanCondon @sys-orch-approve
+/argocd/applications/templates/app* @scottmbaker @adibrastegarnia @SeanCondon @badhrinathpa @pudelkoM @guptagunjan @sys-orch-approve
+/argocd/applications/configs/app* @scottmbaker @adibrastegarnia @SeanCondon @badhrinathpa @pudelkoM @guptagunjan @sys-orch-approve
+/argocd/applications/custom/app* @scottmbaker @adibrastegarnia @SeanCondon @badhrinathpa @pudelkoM @guptagunjan  @sys-orch-approve
 
 # UI templates and values
 /argocd/applications/**/web-ui* @teone @fjcooper5 @satya-in @mamanzan @RPG-coder-intc @dlemiech @riyaz-ghati @vigneshintel

--- a/argocd/applications/templates/app-orch-tenant-controller.yaml
+++ b/argocd/applications/templates/app-orch-tenant-controller.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: app/charts/{{$appName}}
-      targetRevision: 0.3.6
+      targetRevision: 0.3.8
       helm:
         releaseName: {{$appName}}
         valuesObject:

--- a/argocd/applications/templates/app-orch-tenant-controller.yaml
+++ b/argocd/applications/templates/app-orch-tenant-controller.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: app/charts/{{$appName}}
-      targetRevision: 0.3.5
+      targetRevision: 0.3.6
       helm:
         releaseName: {{$appName}}
         valuesObject:

--- a/argocd/applications/templates/app-service-proxy.yaml
+++ b/argocd/applications/templates/app-service-proxy.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: app/charts/{{$appName}}
-      targetRevision: 1.4.2
+      targetRevision: 1.4.3
       helm:
         releaseName: {{$appName}}
         valuesObject:

--- a/e2e-tests/orchestrator/catalog_bootstrap_test.go
+++ b/e2e-tests/orchestrator/catalog_bootstrap_test.go
@@ -347,7 +347,8 @@ var _ = Describe("Provisioned registries push test", Label("orchestrator-integra
 				tlsConfiguration := &tls.Config{ //nolint: gosec
 					RootCAs: caPool,
 				}
-				baseRegistryURL := strings.TrimSuffix(strings.Replace(reg.RootURL, "oci://", "https://", 1), harborProjectName) + "api/v2.0/"
+				baseRegistryURL := strings.TrimSuffix(
+					strings.Replace(reg.RootURL, "oci://", "https://", 1), harborProjectDisplayName) + "api/v2.0/"
 				doHarborREST(ctx, tlsConfiguration, "GET", baseRegistryURL+"projects/"+harborProjectName+
 					"/repositories?q=name%3D"+harborProjectName+"%2F"+imageName,
 					reg.Username, reg.AuthToken, http.StatusOK, checkRESTResponse)

--- a/e2e-tests/orchestrator/catalog_bootstrap_test.go
+++ b/e2e-tests/orchestrator/catalog_bootstrap_test.go
@@ -171,7 +171,7 @@ var _ = Describe("Config Provisioner integration test", Label("orchestrator-inte
 
 				harborDockerOCIReg := GetRegistry(ctx, c, accessToken, testProject, "harbor-docker-oci", http.StatusOK, checkRESTResponse)
 				checkRegistry(harborDockerOCIReg, "harbor oci docker", "Harbor OCI docker images registry", "IMAGE",
-					"https://registry-oci."+serviceDomain+"/")
+					"oci://registry-oci."+serviceDomain+"/"+harborProjectDisplayName)
 				checkLoginCredentials(ctx, harborDockerOCIReg, harborProjectName)
 
 				intelRSHelmReg := GetRegistry(ctx, c, accessToken, testProject, "intel-rs-helm", http.StatusOK, checkRESTResponse)
@@ -319,7 +319,7 @@ var _ = Describe("Provisioned registries push test", Label("orchestrator-integra
 				imageVer := "latest"
 
 				regDomain := reg.RootURL[strings.LastIndex(reg.RootURL, "//")+2:]
-				remoteImageName := fmt.Sprintf("%s/%s/%s:%s", strings.TrimRight(regDomain, "/"), harborProjectName, imageName, imageVer)
+				remoteImageName := fmt.Sprintf("%s/%s:%s", strings.TrimRight(regDomain, "/"), imageName, imageVer)
 
 				err = dc.ImageTag(ctx, imageName+":"+imageVer, remoteImageName)
 				Expect(err).ToNot(HaveOccurred(), "tagging docker image %s as %s", imageName+":"+imageVer, remoteImageName)
@@ -347,7 +347,7 @@ var _ = Describe("Provisioned registries push test", Label("orchestrator-integra
 				tlsConfiguration := &tls.Config{ //nolint: gosec
 					RootCAs: caPool,
 				}
-				baseRegistryURL := reg.RootURL + "api/v2.0/"
+				baseRegistryURL := strings.TrimSuffix(strings.Replace(reg.RootURL, "oci://", "https://", 1), harborProjectName) + "api/v2.0/"
 				doHarborREST(ctx, tlsConfiguration, "GET", baseRegistryURL+"projects/"+harborProjectName+
 					"/repositories?q=name%3D"+harborProjectName+"%2F"+imageName,
 					reg.Username, reg.AuthToken, http.StatusOK, checkRESTResponse)


### PR DESCRIPTION
### Description

Bump Tenant Controller to 0.3.8
* This add support for upgrade of cluster extensions ([link](https://github.com/open-edge-platform/app-orch-tenant-controller/pull/17))
* Sets the rootUrl of the harbor-oci-registry to include the harbor project name ([link1](https://github.com/open-edge-platform/app-orch-tenant-controller/pull/36), [link2](https://github.com/open-edge-platform/app-orch-tenant-controller/pull/37))

Bump App Service Proxy to 1.4.3
* Fixes a problem with Cross-Origin-Embedder-Policy on proxied applications ([link](https://github.com/open-edge-platform/app-orch-deployment/pull/88))

Fixes # ITEP-67065, ITEP-21737

### Any Newly Introduced Dependencies

None

### How Has This Been Tested?

Ran on coder and local tests

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes
- [X] I have not introduced any 3rd party dependency changes
- [X] I have performed a self-review of my code
