### PR TITLE
Update tenancy-api-mapping to 0.5.0

### DIFF
--- a/argocd/applications/templates/tenancy-api-mapping.yaml
+++ b/argocd/applications/templates/tenancy-api-mapping.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: common/charts/{{$appName}}
-      targetRevision: 0.4.1
+      targetRevision: 0.5.0
       helm:
         releaseName: {{$appName}}
         valuesObject:


### PR DESCRIPTION
### Description

Use tenancy-api-mapping chart 0.5.0 (container 1.4.0), per updates in https://github.com/open-edge-platform/orch-utils/pull/100

Fixes # various

### Any Newly Introduced Dependencies

None 

### How Has This Been Tested?

Build/run of container locally

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes
- [X] I have not introduced any 3rd party dependency changes
- [X] I have performed a self-review of my code