### PR TITLE
Set apiv2 in infra-core as default REST API Server

### DIFF
--- a/argocd/applications/templates/infra-core.yaml
+++ b/argocd/applications/templates/infra-core.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: infra/charts/{{$appName}}
-      targetRevision: 2.8.2
+      targetRevision: 2.9.1
       helm:
         releaseName: {{$appName}}
         valuesObject:

--- a/argocd/applications/templates/tenancy-api-mapping.yaml
+++ b/argocd/applications/templates/tenancy-api-mapping.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: common/charts/{{$appName}}
-      targetRevision: 0.4.1
+      targetRevision: 0.6.0
       helm:
         releaseName: {{$appName}}
         valuesObject:


### PR DESCRIPTION
### Description

This releases apiv2 chart in infra-core, setting it as the default REST API Server of EIM. 
The proper changes in tenant-api-mapping are done and released to support this change.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
