### PR TITLE
bump ADM to 2.4.11

### DIFF
--- a/argocd/applications/templates/app-deployment-crd.yaml
+++ b/argocd/applications/templates/app-deployment-crd.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: app/charts/{{$appName}}
-      targetRevision: 2.4.9
+      targetRevision: 2.4.11
       helm:
         releaseName: {{$appName}}
         valuesObject:

--- a/argocd/applications/templates/app-deployment-manager.yaml
+++ b/argocd/applications/templates/app-deployment-manager.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: app/charts/{{$appName}}
-      targetRevision: 2.4.9
+      targetRevision: 2.4.11
       helm:
         releaseName: {{$appName}}
         valuesObject:


### PR DESCRIPTION
### Description

Bump ADM to 2.4.11
* Fixes a problem with the ImagePullSecrets when hosting images in harbor-docker-oci (local harbor) - [link](https://github.com/open-edge-platform/app-orch-deployment/pull/92)
* Shorten the bundle name to allow more space for the app deployment name ([link](https://github.com/open-edge-platform/app-orch-deployment/pull/87))

Fixes # ITEP-67065

### Any Newly Introduced Dependencies

None

### How Has This Been Tested?

Run on coder

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes
- [X] I have not introduced any 3rd party dependency changes
- [X] I have performed a self-review of my code
