### PR TITLE
chore: only run deploy-kind / deploy-onprem when change does not include new-installer

### DIFF
--- a/.github/workflows/virtual-integration.yml
+++ b/.github/workflows/virtual-integration.yml
@@ -61,7 +61,7 @@ jobs:
       terraform: ${{ contains(steps.check-files.outputs.changed_files, '.hcl') || contains(steps.check-files.outputs.changed_files, '.tf') || contains(steps.check-files.outputs.changed_files, '.tfvars') }}
       yaml: ${{ contains(steps.check-files.outputs.changed_files, '.yaml') || contains(steps.check-files.outputs.changed_files, '.yml') }}
       helm: ${{ contains(steps.check-files.outputs.changed_files, 'argocd/') || contains(steps.check-files.outputs.changed_files, 'argocd-internal/') }}
-      not-new-installer: ${{ !contains(steps.check-files.outputs.changed_files, 'new-installers') }}
+      not-installer: ${{ !contains(steps.check-files.outputs.changed_files, 'new-installers') }}
 
     steps:
       - name: Checkout code
@@ -448,7 +448,7 @@ jobs:
       github.ref == 'refs/heads/main' ||
       github.ref == 'refs/heads/main-pass-validation'
       ) &&
-      needs.check-changed-files.outputs.not-new-installer
+      needs.check-changed-files.outputs.not-installer
     runs-on: ubuntu-24.04-16core-64GB
     timeout-minutes: 90
     env:
@@ -684,7 +684,7 @@ jobs:
       github.ref == 'refs/heads/main' ||
       github.ref == 'refs/heads/main-pass-validation'
       ) &&
-      needs.check-changed-files.outputs.not-new-installer
+      needs.check-changed-files.outputs.not-installer
     runs-on: ubuntu-24.04-16core-64GB
     timeout-minutes: 120
     env:

--- a/.github/workflows/virtual-integration.yml
+++ b/.github/workflows/virtual-integration.yml
@@ -61,6 +61,8 @@ jobs:
       terraform: ${{ contains(steps.check-files.outputs.changed_files, '.hcl') || contains(steps.check-files.outputs.changed_files, '.tf') || contains(steps.check-files.outputs.changed_files, '.tfvars') }}
       yaml: ${{ contains(steps.check-files.outputs.changed_files, '.yaml') || contains(steps.check-files.outputs.changed_files, '.yml') }}
       helm: ${{ contains(steps.check-files.outputs.changed_files, 'argocd/') || contains(steps.check-files.outputs.changed_files, 'argocd-internal/') }}
+      not-new-installer: ${{ !contains(steps.check-files.outputs.changed_files, 'new-installers') }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
@@ -445,7 +447,8 @@ jobs:
       needs.check-changed-files.outputs.ci == 'true' ||
       github.ref == 'refs/heads/main' ||
       github.ref == 'refs/heads/main-pass-validation'
-      )
+      ) &&
+      needs.check-changed-files.outputs.not-new-installer
     runs-on: ubuntu-24.04-16core-64GB
     timeout-minutes: 90
     env:
@@ -680,7 +683,8 @@ jobs:
       needs.check-changed-files.outputs.ci == 'true' ||
       github.ref == 'refs/heads/main' ||
       github.ref == 'refs/heads/main-pass-validation'
-      )
+      ) &&
+      needs.check-changed-files.outputs.not-new-installer
     runs-on: ubuntu-24.04-16core-64GB
     timeout-minutes: 120
     env:


### PR DESCRIPTION
### Description

Exclude installer from Kind VIP / On-Prem VIP for now.
We can later reintroduce it back to On-Prem VIP


### Any Newly Introduced Dependencies

N/A

### How Has This Been Tested?

N/A

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
