### PR TITLE
feat: Update tenancy-api-mapping chart to 0.6.3 for vPro APIs

### DIFF
--- a/argocd/applications/templates/tenancy-api-mapping.yaml
+++ b/argocd/applications/templates/tenancy-api-mapping.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: common/charts/{{$appName}}
-      targetRevision: 0.5.0
+      targetRevision: 0.6.3
       helm:
         releaseName: {{$appName}}
         valuesObject:


### PR DESCRIPTION
### Description

Update tenancy-api-mapping to 0.6.3 per https://github.com/open-edge-platform/orch-utils/pull/106

### Any Newly Introduced Dependencies

N/A

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes
- [X] I have not introduced any 3rd party dependency changes
- [X] I have performed a self-review of my code