### PR TITLE
add proxy settings to app-orch-catalog

### DIFF
--- a/argocd/applications/custom/app-orch-catalog.tpl
+++ b/argocd/applications/custom/app-orch-catalog.tpl
@@ -29,3 +29,14 @@ openidc:
 {{- if .Values.argo.catalog.storageClass }}
 storageClassName: {{ .Values.argo.catalog.storageClass }}
 {{- end }}
+catalogServer:
+  # http proxy settings
+  {{- if .Values.argo.proxy.httpProxy}}
+  httpProxy: "{{ .Values.argo.proxy.httpProxy }}"
+  {{- end}}
+  {{- if .Values.argo.proxy.httpsProxy}}
+  httpsProxy: "{{ .Values.argo.proxy.httpsProxy }}"
+  {{- end}}
+  {{- if .Values.argo.proxy.noProxy}}
+  noProxy: "{{ .Values.argo.proxy.noProxy }}"
+  {{- end}}

--- a/argocd/applications/templates/app-deployment-manager.yaml
+++ b/argocd/applications/templates/app-deployment-manager.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: app/charts/{{$appName}}
-      targetRevision: 2.4.11
+      targetRevision: 2.4.12
       helm:
         releaseName: {{$appName}}
         valuesObject:

--- a/argocd/applications/templates/app-orch-catalog.yaml
+++ b/argocd/applications/templates/app-orch-catalog.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: app/charts/{{$appName}}
-      targetRevision: 0.14.1
+      targetRevision: 0.14.3
       helm:
         releaseName: {{ $appName }}
         valuesObject:


### PR DESCRIPTION
### Description

Updates app-orch-catalog to 0.14.2 and sets the proxy settings to be used inside the container. Prerequisite for catalog import feature. Also, bump ADM to l2.4.12 to pull in fix for flipping state.

### Any Newly Introduced Dependencies

No

### How Has This Been Tested?

Tested in Coder.

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
