### PR TITLE
Remove CODEOWNER enforcement on dependency files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,29 @@
 # Everything requires Platform team review by default
 * @se-chris-thach @mdbalvin @rad-szulim @charlesmcchan @yi-tseng-intel @ashridatta @teone @callumnobleintel @daniele-moro @SeanCondon @pierventre @cgoea john.oloughlin@intel.com gary.loughnane@intel.com @palade @pperycz @ltalarcz @jakubsikorski @sys-orch-approve @ahalimx86
 
+# Dependabot is used to manage dependencies in this repository. It is configured to automatically open pull requests to
+# update dependencies when new versions are available. The following files are managed by Dependabot and do not require
+# manual review or approval for changes. However, if you want to review the changes made by Dependabot, you can do so
+# by checking the pull requests it opens. This workaround was shared in
+# https://github.com/orgs/community/discussions/23064#discussioncomment-8383923 and can be removed once GitHub properly
+# supports CODEOWNERS for GitHub apps.
+# Go modules dependencies
+**/*.mod
+**/*.sum
+# Terraform dependencies
+**/*.tf
+**/*.tfvars
+**/*.tfstate
+**/*.tfstate.backup
+# Helm dependencies
+**/Chart.yaml
+**/values.yaml
+# Docker dependencies
+**/Dockerfile
+# GitHub Actions dependencies
+/.github/workflows/*.yml
+/.github/workflows/*.yaml
+
 # Except the following folders, which can be merged with passing CI and one approval
 /argocd/applications/templates
 /ci/


### PR DESCRIPTION

### Description

Workaround as described in https://github.com/orgs/community/discussions/23064#discussioncomment-8383923 to allow Dependabot PRs to be auto-merged without CODEOWNER review.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
