### PR TITLE
Remove gitea package from the uninstall script

### DIFF
--- a/on-prem-installers/onprem/uninstall_onprem.sh
+++ b/on-prem-installers/onprem/uninstall_onprem.sh
@@ -11,7 +11,6 @@ set -o pipefail
 # Packages in order of removal - reverse order to installation
 packages=(
     onprem-orch-installer
-    onprem-gitea-installer
     onprem-argocd-installer
     onprem-ke-installer
 )


### PR DESCRIPTION
### Description

The contents of gitea package have been moved into the argocd package.

Fixes # (issue)

### Any Newly Introduced Dependencies

None

### How Has This Been Tested?

Locally and CI

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
