### PR TITLE
Checking out the EMF repo regardless of where the GHA is invoked

### DIFF
--- a/.github/actions/deploy_kind/action.yaml
+++ b/.github/actions/deploy_kind/action.yaml
@@ -35,6 +35,8 @@ runs:
   - name: Checkout code
     uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
     with:
+      repository: open-edge-platform/edge-manageability-framework
+      ref: ${{ inputs.orch_version }}
       persist-credentials: false
 
   - name: Set up git credentials


### PR DESCRIPTION
### Description

Required to use the `deploy_kind` GHA from other repos

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
