### PR TITLE
Update tools in .tool-version

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -2,7 +2,7 @@ argocd 2.10.10
 awscli 2.17.52
 docker-compose-v1 2.17.3
 ginkgo 2.22.2
-golang 1.24.1
+golang 1.24.4
 golangci-lint 1.64.7
 grpcurl 1.8.9
 helm 3.11.1


### PR DESCRIPTION
### Description

Update tool versions installed by asdf - see dates below

jq 1.6 (November 2018) -> 1.8.0 (June 2025)

shellcheck 0.9.0 (December 2022) -> v0.10.0 (March 2024)

yamllint 1.26.3 (August 2023) -> 1.37.1 (May 2025)

yq 4.34.2 (July 2023) -> 4.45.4 (May 2025)

nodejs 23.6.1 (Jan 2025) -> 24.2.0 (June 2025) - 23.x is out of support per: https://nodejs.org/en/about/previous-releases

### Any Newly Introduced Dependencies

See versions updates above. 

### How Has This Been Tested?

in progress

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code