### PR TITLE
fix(config): support single hostname, with or without leading dot (localhost, .svc) in no proxy

### DIFF
--- a/new-installer/cmd/config/validate.go
+++ b/new-installer/cmd/config/validate.go
@@ -244,7 +244,7 @@ func validateNoProxy(s string) error {
 	}
 	entries := strings.Split(s, ",")
 	ipRe := regexp.MustCompile(`^([0-9]{1,3}\.){3}[0-9]{1,3}(\/\d{1,2})?$`)
-	domainRe := regexp.MustCompile(`^\.?([a-z0-9.-]+\.[a-z]{2,})$`)
+	domainRe := regexp.MustCompile(`^\.?[a-zA-Z]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9-]+)*$`)
 	for _, entry := range entries {
 		e := strings.TrimSpace(entry)
 		if e == "" {

--- a/new-installer/cmd/config/validate_test.go
+++ b/new-installer/cmd/config/validate_test.go
@@ -824,6 +824,16 @@ func (s *OrchConfigValidationTest) TestValidateNoProxy() {
 			wantErr: false,
 		},
 		{
+			name:    "valid host name without domain",
+			input:   "localhost",
+			wantErr: false,
+		},
+		{
+			name:    "valid domain with leading dot",
+			input:   ".onprem",
+			wantErr: false,
+		},
+		{
 			name:    "multiple valid domains and IPs",
 			input:   "example.com,192.168.1.1,.internal.local",
 			wantErr: false,
@@ -885,10 +895,9 @@ func (s *OrchConfigValidationTest) TestValidateNoProxy() {
 			errMsg:  "invalid no_proxy entry: 10.0.-1.1",
 		},
 		{
-			name:    "invalid domain with uppercase",
+			name:    "valid domain with uppercase",
 			input:   "Example.com",
-			wantErr: true,
-			errMsg:  "invalid no_proxy entry: Example.com",
+			wantErr: false,
 		},
 		{
 			name:    "valid domain with dash",


### PR DESCRIPTION
### Description

fix(config): support single hostname, with or without leading dot (localhost, .svc) in no proxy

### Any Newly Introduced Dependencies

N/A

### How Has This Been Tested?

Unit test

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
