### PR TITLE
fix(installer) Fixing multiple issues when running the installer

### DIFF
--- a/new-installer/cmd/orch_installer.go
+++ b/new-installer/cmd/orch_installer.go
@@ -35,7 +35,7 @@ func main() {
 	var configFile, runtimeStateFile, logLevel, logDir, targets string
 	var keepGeneratedFiles bool
 	rootCmd.PersistentFlags().StringVarP(&configFile, "config", "c", "config.yaml", "Path to the configuration file")
-	rootCmd.PersistentFlags().StringVarP(&runtimeStateFile, "runtime-state", "r", "config.yaml", "Path to the runtime state file")
+	rootCmd.PersistentFlags().StringVarP(&runtimeStateFile, "runtime-state", "r", "runtime-state.yaml", "Path to the runtime state file")
 	rootCmd.PersistentFlags().StringVarP(&logLevel, "log-level", "l", "info", "Log level (debug, info, warn, error)")
 	rootCmd.PersistentFlags().StringVarP(&logDir, "log-dir", "o", ".logs", "Path to the log dir")
 	rootCmd.PersistentFlags().BoolVarP(&keepGeneratedFiles, "keep-generated-files", "k", false, "Keep generated files, such as Terraform backend config and variables files.")
@@ -100,6 +100,13 @@ func execute(action string, orchConfigFile string, runtimeStateFile string, logD
 	orchConfig, err := orchConfigReaderWriter.ReadOrchConfig()
 	if err != nil {
 		logger.Fatalf("error reading config file %s: %s", orchConfigFile, err)
+	}
+	if _, err := os.Stat(runtimeStateFile); os.IsNotExist(err) {
+		logger.Infof("Runtime state file %s does not exist, creating a new one.", runtimeStateFile)
+		err = orchConfigReaderWriter.WriteRuntimeState(config.OrchInstallerRuntimeState{})
+		if err != nil {
+			logger.Fatalf("error creating runtime state file: %s", err)
+		}
 	}
 	runtimeState, err := orchConfigReaderWriter.ReadRuntimeState()
 	if err != nil {

--- a/new-installer/cmd/orch_installer.go
+++ b/new-installer/cmd/orch_installer.go
@@ -195,16 +195,16 @@ func showActionsForError(err *internal.OrchInstallerError) {
 	logger := zap.S()
 	switch err.ErrorCode {
 	case internal.OrchInstallerErrorCodeUnknown:
-		logger.Error("An unknown error occurred, please check the logs for more details.")
+		logger.Info("An unknown error occurred, please check the logs for more details.")
 	case internal.OrchInstallerErrorCodeInternal:
-		logger.Error("An internal error occurred, please check the logs for more details.")
+		logger.Info("An internal error occurred, please check the logs for more details.")
 	case internal.OrchInstallerErrorCodeInvalidArgument:
-		logger.Error("Invalid argument provided, please check the configuration file and command line arguments.")
+		logger.Info("Invalid argument provided, please check the configuration file and command line arguments.")
 	case internal.OrchInstallerErrorCodeInvalidRuntimeState:
-		logger.Error("Invalid runtime state, please check the runtime state file.")
+		logger.Info("Invalid runtime state, please check the runtime state file.")
 	case internal.OrchInstallerErrorCodeTerraform:
-		logger.Error("An error occurred while running Terraform, please check the Terraform logs for more details.")
+		logger.Info("An error occurred while running Terraform, please check the Terraform logs for more details.")
 	default:
-		logger.Error("An unexpected error occurred, please check the logs for more details.")
+		logger.Info("An unexpected error occurred, please check the logs for more details.")
 	}
 }

--- a/new-installer/internal/steps/aws/state_bucket.go
+++ b/new-installer/internal/steps/aws/state_bucket.go
@@ -97,6 +97,12 @@ func (s *AWSStateBucketStep) RunStep(ctx context.Context, config config.OrchInst
 		LogFile:            filepath.Join(s.RootPath, ".logs", "aws_state_bucket.log"),
 		KeepGeneratedFiles: s.KeepGeneratedFiles,
 	})
+	if err != nil {
+		return runtimeState, &internal.OrchInstallerError{
+			ErrorCode: internal.OrchInstallerErrorCodeInternal,
+			ErrorMsg:  fmt.Sprintf("Failed to run Terraform for AWS state bucket: %v", err),
+		}
+	}
 	if runtimeState.Action != "uninstall" && output.TerraformState == "" {
 		return runtimeState, &internal.OrchInstallerError{
 			ErrorCode: internal.OrchInstallerErrorCodeInternal,

--- a/new-installer/internal/steps/aws/state_bucket.go
+++ b/new-installer/internal/steps/aws/state_bucket.go
@@ -96,6 +96,7 @@ func (s *AWSStateBucketStep) RunStep(ctx context.Context, config config.OrchInst
 		Variables:          s.variables,
 		LogFile:            filepath.Join(s.RootPath, ".logs", "aws_state_bucket.log"),
 		KeepGeneratedFiles: s.KeepGeneratedFiles,
+		TerraformState:     runtimeState.StateBucketState,
 	})
 	if err != nil {
 		return runtimeState, &internal.OrchInstallerError{

--- a/new-installer/internal/steps/aws/utils_test.go
+++ b/new-installer/internal/steps/aws/utils_test.go
@@ -104,3 +104,8 @@ func (m *MockAWSUtility) GetSubnetIDsFromVPC(region, vpcID string) ([]string, []
 	}
 	return privateSubnets, publicSubnets, err
 }
+
+func (m *MockAWSUtility) EmptyS3Bucket(region, bucket string) error {
+	args := m.Called(region, bucket)
+	return args.Error(0)
+}

--- a/new-installer/internal/steps/aws/vpc.go
+++ b/new-installer/internal/steps/aws/vpc.go
@@ -74,7 +74,8 @@ func NewDefaultVPCVariables() VPCVariables {
 		CidrBlock:              "",
 		EnableDnsHostnames:     true,
 		EnableDnsSupport:       true,
-		JumphostIPAllowList:    []string{},
+		Endpoints:              VPCEndpoints,
+		JumphostIPAllowList:    make([]string, 0),
 		JumphostInstanceSSHKey: "",
 		Production:             true,
 		CustomerTag:            "",
@@ -137,6 +138,7 @@ func (s *VPCStep) ConfigStep(ctx context.Context, config config.OrchInstallerCon
 	s.variables.Name = config.Global.OrchName
 	s.variables.CidrBlock = DefaultNetworkCIDR
 	s.variables.EndpointSGName = config.Global.OrchName + "-vpc-ep"
+	s.variables.Endpoints = VPCEndpoints
 
 	// Based on the region, we need to get the availability zones.
 	availabilityZones, err := s.AWSUtility.GetAvailableZones(config.AWS.Region)

--- a/new-installer/targets/aws/aws.go
+++ b/new-installer/targets/aws/aws.go
@@ -59,7 +59,7 @@ func CreateAWSStages(rootPath string, keepGeneratedFiles bool, orchConfigReaderW
 			steps_aws.CreateVPCStep(rootPath, keepGeneratedFiles, tfUtil, aws_util),
 		}, []string{"pre-infra"}, orchConfigReaderWriter),
 		NewAWSStage("Infra", []steps.OrchInstallerStep{
-			steps_aws.CreateEFSStep(rootPath, keepGeneratedFiles, tfUtil, aws_util),
+			// steps_aws.CreateEFSStep(rootPath, keepGeneratedFiles, tfUtil, aws_util),
 			steps_aws.CreateObservabilityBucketsStep(rootPath, keepGeneratedFiles, tfUtil, aws_util),
 			steps_aws.CreateKMSStep(rootPath, keepGeneratedFiles, tfUtil, aws_util),
 		}, []string{"infra"}, orchConfigReaderWriter),

--- a/new-installer/targets/aws/aws.go
+++ b/new-installer/targets/aws/aws.go
@@ -55,7 +55,7 @@ func CreateAWSStages(rootPath string, keepGeneratedFiles bool, orchConfigReaderW
 	aws_util := steps_aws.CreateAWSUtility()
 	return []internal.OrchInstallerStage{
 		NewAWSStage("PreInfra", []steps.OrchInstallerStep{
-			steps_aws.CreateAWSStateBucketStep(rootPath, keepGeneratedFiles, tfUtil),
+			steps_aws.CreateStateBucketStep(rootPath, keepGeneratedFiles, tfUtil),
 			steps_aws.CreateVPCStep(rootPath, keepGeneratedFiles, tfUtil, aws_util),
 		}, []string{"pre-infra"}, orchConfigReaderWriter),
 		NewAWSStage("Infra", []steps.OrchInstallerStep{

--- a/new-installer/targets/aws/aws.go
+++ b/new-installer/targets/aws/aws.go
@@ -60,7 +60,7 @@ func CreateAWSStages(rootPath string, keepGeneratedFiles bool, orchConfigReaderW
 		}, []string{"pre-infra"}, orchConfigReaderWriter),
 		NewAWSStage("Infra", []steps.OrchInstallerStep{
 			// steps_aws.CreateEFSStep(rootPath, keepGeneratedFiles, tfUtil, aws_util),
-			steps_aws.CreateObservabilityBucketsStep(rootPath, keepGeneratedFiles, tfUtil, aws_util),
+			// steps_aws.CreateObservabilityBucketsStep(rootPath, keepGeneratedFiles, tfUtil, aws_util),
 			steps_aws.CreateKMSStep(rootPath, keepGeneratedFiles, tfUtil, aws_util),
 		}, []string{"infra"}, orchConfigReaderWriter),
 	}, nil

--- a/new-installer/targets/aws/aws.go
+++ b/new-installer/targets/aws/aws.go
@@ -22,7 +22,6 @@ import (
 func installTerraform() (execPath string, err error) {
 	ctx := context.Background()
 	i := install.NewInstaller()
-	defer i.Remove(ctx)
 	v1_3 := version.Must(version.NewVersion(steps.TerraformVersion))
 	execPath, err = i.Install(ctx, []src.Installable{
 		&releases.ExactVersion{

--- a/new-installer/targets/aws/stage.go
+++ b/new-installer/targets/aws/stage.go
@@ -90,5 +90,5 @@ func (a *AWSStage) RunStage(ctx context.Context, config *config.OrchInstallerCon
 }
 
 func (a *AWSStage) PostStage(ctx context.Context, config *config.OrchInstallerConfig, runtimeState *config.OrchInstallerRuntimeState, prevStageError *internal.OrchInstallerError) *internal.OrchInstallerError {
-	return nil
+	return prevStageError
 }


### PR DESCRIPTION
### Description

This PR addresses the following issues:
- When starting the installer, we need to create runtime state file if it is missing.
- The runtime state file should use a different name instead of config.yml
- Fix error handling, the post stage should return the error it got
- Fix terraform utility
- Stateu bucket step should handle error from Terraform utility
- Nicer error output
- Must include prevous bucket state when applying state bucket module
- Avoid setting endpoint and jumphost allow list with null

### Any Newly Introduced Dependencies

N/A

### How Has This Been Tested?

Via HIP

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
