### PR TITLE
Revert "Consolidate on-prem-installer deb packages (#363)"

### DIFF
--- a/on-prem-installers/cmd/onprem-argo-cd/after-install.sh
+++ b/on-prem-installers/cmd/onprem-argo-cd/after-install.sh
@@ -6,14 +6,6 @@
 
 set -o errexit
 
-export KUBECONFIG=/home/$USER/.kube/config
-
-# Add /usr/local/bin to the PATH as some utilities, like kubectl, could be installed there
-export PATH=$PATH:/usr/local/bin
-
-IMAGE_REGISTRY="${IMAGE_REGISTRY:-docker.io}"
-
-install_argocd() {
 cat << "EOF"
 
      _                     ____ ____
@@ -25,6 +17,10 @@ cat << "EOF"
 
 EOF
 
+export KUBECONFIG=/home/$USER/.kube/config
+
+# Add /usr/local/bin to the PATH as some utilities, like kubectl, could be installed there
+export PATH=$PATH:/usr/local/bin
 
 cp /tmp/argo-cd/values.tmpl /tmp/argo-cd/argo-cd/templates/values.tmpl
 # helm treats comma as separator in '--set' command, so multiple no_proxy values are treated as different env values, so we have to write them to file first
@@ -92,127 +88,3 @@ applicationSet:
       path: /usr/local/share/ca-certificates/gitea_cert.crt
 " > /tmp/argo-cd/mounts.yaml
 helm install argocd /tmp/argo-cd/argo-cd --values /tmp/argo-cd/values.yaml -f /tmp/argo-cd/mounts.yaml -n argocd --create-namespace
-}
-
-
-processSAN() {
-  local result="subjectAltName=DNS:localhost"
-  for domain in "$@"; do
-    result="${result},DNS:${domain}"
-  done
-  echo "${result}"
-}
-
-processCerts() {
-  echo "Generating key..."
-
-  if ! openssl version; then
-    echo "OpenSSL not found!"
-    exit 1
-  fi
-
-  openssl="openssl"
-
-  tmpDir=$(mktemp -d)
-  $openssl genrsa -out "$tmpDir/infra-tls.key" 4096
-
-  echo "Generating certificate..."
-  san=$(processSAN "$@")
-  # Generate the certificate with the name infra-tls.crt
-  $openssl req -key "$tmpDir/infra-tls.key" -new -x509 -days 365 -out "$tmpDir/infra-tls.crt" -subj "/C=US/O=Orch Deploy/OU=Orchestrator" -addext "$san"
-  cp "${tmpDir}"/infra-tls.crt /usr/local/share/ca-certificates/gitea_cert.crt
-  update-ca-certificates
-
-  # Create a tls secret with custom key names
-  kubectl create secret tls gitea-tls-certs -n gitea \
-    --cert="$tmpDir/infra-tls.crt" \
-    --key="$tmpDir/infra-tls.key"
-
-  # Clean up the temporary directory
-  rm -rf "$tmpDir"
-}
-
-randomPassword() {
-  tr -dc A-Za-z0-9 </dev/urandom | head -c 16
-}
-
-createGiteaSecret() {
-  local secretName=$1
-  local accountName=$2
-  local password=$3
-  local namespace=$4
-
-  kubectl create secret generic "$secretName" -n "$namespace" \
-    --from-literal=username="$accountName" \
-    --from-literal=password="$password" \
-    --dry-run=client -o yaml | kubectl apply -f -
-}
-
-createGiteaAccount() {
-  local secretName=$1
-  local accountName=$2
-  local password=$3
-  local email=$4
-  local giteaPods=""
-  local giteaPod=""
-
-  giteaPods=$(kubectl get pods -n gitea -l app=gitea -o jsonpath="{.items[*].metadata.name}")
-  if [ -z "$giteaPods" ]; then
-    echo "No Gitea pods found. Exiting."
-    exit 1
-  fi
-
-  giteaPod=$(echo "$giteaPods" | cut -d ' ' -f1)
-  if ! kubectl exec -n gitea "$giteaPod" -c "gitea" -- gitea admin user list | grep -q "$accountName"; then
-    echo "Creating Gitea account for $accountName"
-    kubectl exec -n gitea "$giteaPod" -c "gitea" -- gitea admin user create --username "$accountName" --password "$password" --email "$email" --must-change-password=false
-  else
-    echo "Gitea account for $accountName already exists, updating password"
-    kubectl exec -n gitea "$giteaPod" -c "gitea" -- gitea admin user change-password --username "$accountName" --password "$password" --must-change-password=false
-  fi
-
-  userToken=$(kubectl exec -n gitea "$giteaPod" -c gitea -- gitea admin user generate-access-token --scopes write:repository,write:user --username $accountName --token-name "${accountName}-$(date +%s)")
-  token=$(echo $userToken | awk '{print $NF}')
-  kubectl create secret generic gitea-$accountName-token -n gitea --from-literal=token=$token
-}
-
-install_gitea() {
-cat << "EOF"
-
-   ____ _ _
-  / ___(_) |_ ___  __ _
- | |  _| | __/ _ \/ _` |
- | |_| | | ||  __/ (_| |
-  \____|_|\__\___|\__,_|
-
-
-EOF
-
-  kubectl create ns gitea >/dev/null 2>&1 || true
-  kubectl create ns orch-platform >/dev/null 2>&1 || true
-  kubectl -n gitea get secret gitea-tls-certs >/dev/null 2>&1 || processCerts gitea-http.gitea.svc.cluster.local
-
-  adminGiteaPassword=$(randomPassword)
-  argocdGiteaPassword=$(randomPassword)
-  appGiteaPassword=$(randomPassword)
-  clusterGiteaPassword=$(randomPassword)
-
-  # Create secret for Gitea admin user but should not be used for normal operations
-  createGiteaSecret "gitea-cred" "gitea_admin" "$adminGiteaPassword" "gitea"
-
-  # Create user credential secrets for ArgoCD, AppOrch and ClusterOrch
-  createGiteaSecret "argocd-gitea-credential" "argocd" "$argocdGiteaPassword" "gitea"
-  createGiteaSecret "app-gitea-credential" "apporch" "$appGiteaPassword" "orch-platform"
-  createGiteaSecret "cluster-gitea-credential" "clusterorch" "$clusterGiteaPassword" "orch-platform"
-
-  # More helm values are set in ../assets/gitea/values.yaml
-  helm install gitea /tmp/gitea/gitea --values /tmp/gitea/values.yaml --set gitea.admin.existingSecret=gitea-cred --set image.registry="${IMAGE_REGISTRY}" -n gitea --timeout 15m0s --wait
-
-  # Create Gitea accounts for ArgoCD, AppOrch and ClusterOrch
-  createGiteaAccount "argocd-gitea-credential" "argocd" "$argocdGiteaPassword" "argocd@orch-installer.com"
-  createGiteaAccount "app-gitea-credential" "apporch" "$appGiteaPassword" "apporch@orch-installer.com"
-  createGiteaAccount "cluster-gitea-credential" "clusterorch" "$clusterGiteaPassword" "clusterorch@orch-installer.com"
-}
-
-install_gitea
-install_argocd

--- a/on-prem-installers/cmd/onprem-argo-cd/after-remove.sh
+++ b/on-prem-installers/cmd/onprem-argo-cd/after-remove.sh
@@ -6,13 +6,6 @@
 
 set -o errexit
 
-export KUBECONFIG=/home/$USER/.kube/config
-
-# Add /usr/local/bin to the PATH as some utilities, like kubectl, could be installed there
-export PATH=$PATH:/usr/local/bin
-
-remove_argocd() {   
-
 cat << "EOF"
 
      _                     ____ ____    ____
@@ -24,37 +17,18 @@ cat << "EOF"
 
 EOF
 
-    # If ArgoCD is upgraded its helm chart shouldn't be deleted, as helm upgrade
-    # will be called in after-upgrade
-    if [ "${1}" = "upgrade" ]; then
-        return 0
-    fi
+# If ArgoCD is upgraded its helm chart shouldn't be deleted, as helm upgrade
+# will be called in after-upgrade
+if [ "${1}" = "upgrade" ]; then
+    exit 0
+fi
 
-    helm delete argocd -n argocd || true
+export KUBECONFIG=/home/$USER/.kube/config
 
-    # Remove artifacts
-    rm -rf /tmp/argo-cd || true
-}
+# Add /usr/local/bin to the PATH as some utilities, like kubectl, could be installed there
+export PATH=$PATH:/usr/local/bin
 
+helm delete argocd -n argocd || true
 
-
-remove_gitea() {
-cat << "EOF"
-
-   ____ _ _               ____
-  / ___(_) |_ ___  __ _  |  _ \ ___ _ __ ___   _____   _____
- | |  _| | __/ _ \/ _` | | |_) / _ \ '_ ` _ \ / _ \ \ / / _ \
- | |_| | | ||  __/ (_| | |  _ <  __/ | | | | | (_) \ V /  __/
-  \____|_|\__\___|\__,_| |_| \_\___|_| |_| |_|\___/ \_/ \___|
-
-
-EOF
-
-    helm delete gitea -n gitea || true
-    kubectl delete secret gitea-cred gitea-tls-certs gitea-token -n gitea || true
-    # clean the certificate on the system
-    rm -f /usr/local/share/ca-certificates/gitea_cert.crt || true
-}
-
-remove_gitea
-remove_argocd
+# Remove artifacts
+rm -rf /tmp/argo-cd || true

--- a/on-prem-installers/cmd/onprem-argo-cd/after-upgrade.sh
+++ b/on-prem-installers/cmd/onprem-argo-cd/after-upgrade.sh
@@ -6,15 +6,6 @@
 
 set -o errexit
 
-
-export KUBECONFIG=/home/$USER/.kube/config
-
-# Add /usr/local/bin to the PATH as some utilities, like kubectl, could be installed there
-export PATH=$PATH:/usr/local/bin
-IMAGE_REGISTRY="${IMAGE_REGISTRY:-docker.io}"
-
-upgrade_argocd() {
-
 cat << "EOF"
 
      _                     ____ ____    _   _                           _
@@ -26,6 +17,10 @@ cat << "EOF"
 
 EOF
 
+export KUBECONFIG=/home/$USER/.kube/config
+
+# Add /usr/local/bin to the PATH as some utilities, like kubectl, could be installed there
+export PATH=$PATH:/usr/local/bin
 
 cp /tmp/argo-cd/values.tmpl /tmp/argo-cd/argo-cd/templates/values.tmpl
 # helm treats comma as separator in '--set' command, so multiple no_proxy values are treated as different env values, so we have to write them to file first
@@ -96,127 +91,3 @@ applicationSet:
 echo "ArgoCD Helm Chart is being upgraded, please wait, timeout is set to 10m..."
 helm upgrade argocd /tmp/argo-cd/argo-cd --values /tmp/argo-cd/values.yaml -f /tmp/argo-cd/mounts.yaml -n argocd \
   --wait --timeout 15m0s
-}
-
-
-processSAN() {
-  local result="subjectAltName=DNS:localhost"
-  for domain in "$@"; do
-    result="${result},DNS:${domain}"
-  done
-  echo "${result}"
-}
-
-processCerts() {
-  echo "Generating key..."
-
-  if ! openssl version; then
-    echo "OpenSSL not found!"
-    exit 1
-  fi
-
-  openssl="openssl"
-
-  tmpDir=$(mktemp -d)
-  $openssl genrsa -out "$tmpDir/infra-tls.key" 4096
-
-  echo "Generating certificate..."
-  san=$(processSAN "$@")
-  # Generate the certificate with the name infra-tls.crt
-  $openssl req -key "$tmpDir/infra-tls.key" -new -x509 -days 365 -out "$tmpDir/infra-tls.crt" -subj "/C=US/O=Orch Deploy/OU=Open Edge Platform" -addext "$san"
-  cp "${tmpDir}"/infra-tls.crt /usr/local/share/ca-certificates/gitea_cert.crt
-  update-ca-certificates
-
-  # Create a tls secret with custom key names
-  kubectl create secret tls gitea-tls-certs -n gitea \
-    --cert="$tmpDir/infra-tls.crt" \
-    --key="$tmpDir/infra-tls.key"
-
-  # Clean up the temporary directory
-  rm -rf "$tmpDir"
-}
-
-randomPassword() {
-  tr -dc A-Za-z0-9 </dev/urandom | head -c 16
-}
-
-createGiteaSecret() {
-  local secretName=$1
-  local accountName=$2
-  local password=$3
-  local namespace=$4
-
-  kubectl create secret generic "$secretName" -n "$namespace" \
-    --from-literal=username="$accountName" \
-    --from-literal=password="$password" \
-    --dry-run=client -o yaml | kubectl apply -f -
-}
-
-createGiteaAccount() {
-  local secretName=$1
-  local accountName=$2
-  local password=$3
-  local email=$4
-  local giteaPods=""
-  local giteaPod=""
-
-  giteaPods=$(kubectl get pods -n gitea -l app=gitea -o jsonpath="{.items[*].metadata.name}")
-  if [ -z "$giteaPods" ]; then
-    echo "No Gitea pods found. Exiting."
-    exit 1
-  fi
-
-  giteaPod=$(echo "$giteaPods" | cut -d ' ' -f1)
-  if ! kubectl exec -n gitea "$giteaPod" -c gitea -- gitea admin user list | grep -q "$accountName"; then
-    echo "Creating Gitea account for $accountName"
-    kubectl exec -n gitea "$giteaPod" -c gitea -- gitea admin user create --username "$accountName" --password "$password" --email "$email" --must-change-password=false
-  else
-    echo "Gitea account for $accountName already exists, updating password"
-    kubectl exec -n gitea "$giteaPod" -c gitea -- gitea admin user change-password --username "$accountName" --password "$password" --must-change-password=false
-  fi
-
-  userToken=$(kubectl exec -n gitea "$giteaPod" -c gitea -- gitea admin user generate-access-token --scopes write:repository,write:user --username "$accountName" --token-name "${accountName}-$(date +%s)")
-  token=$(echo "$userToken" | awk '{print $NF}')
-  kubectl create secret generic gitea-"$accountName"-token -n gitea --from-literal=token="$token"
-}
-
-upgrade_gitea() {
-cat << "EOF"
-
-   ____ _ _               _   _                           _
-  / ___(_) |_ ___  __ _  | | | |_ __   __ _ _ __ __ _  __| | ___
- | |  _| | __/ _ \/ _` | | | | | '_ \ / _` | '__/ _` |/ _` |/ _ \
- | |_| | | ||  __/ (_| | | |_| | |_) | (_| | | | (_| | (_| |  __/
-  \____|_|\__\___|\__,_|  \___/| .__/ \__, |_|  \__,_|\__,_|\___|
-                               |_|    |___/
-
-EOF
-
-  kubectl create ns gitea >/dev/null 2>&1 || true
-  kubectl create ns orch-platform >/dev/null 2>&1 || true
-  kubectl -n gitea get secret gitea-tls-certs >/dev/null 2>&1 || processCerts gitea-http.gitea.svc.cluster.local
-
-  adminGiteaPassword=$(randomPassword)
-  argocdGiteaPassword=$(randomPassword)
-  appGiteaPassword=$(randomPassword)
-  clusterGiteaPassword=$(randomPassword)
-
-  # Create secret for Gitea admin user but should not be used for normal operations
-  createGiteaSecret "gitea-cred" "gitea_admin" "$adminGiteaPassword" "gitea"
-
-  # Create user credential secrets for ArgoCD, AppOrch and ClusterOrch
-  createGiteaSecret "argocd-gitea-credential" "argocd" "$argocdGiteaPassword" "gitea"
-  createGiteaSecret "app-gitea-credential" "apporch" "$appGiteaPassword" "orch-platform"
-  createGiteaSecret "cluster-gitea-credential" "clusterorch" "$clusterGiteaPassword" "orch-platform"
-
-  # More helm values are set in ../assets/gitea/values.yaml
-  helm upgrade --install gitea /tmp/gitea/gitea --values /tmp/gitea/values.yaml --set gitea.admin.existingSecret=gitea-cred --set image.registry="${IMAGE_REGISTRY}" -n gitea --timeout 15m0s --wait
-
-  # Create Gitea accounts for ArgoCD, AppOrch and ClusterOrch
-  createGiteaAccount "argocd-gitea-credential" "argocd" "$argocdGiteaPassword" "argocd@orch-installer.com"
-  createGiteaAccount "app-gitea-credential" "apporch" "$appGiteaPassword" "test@test.com"
-  createGiteaAccount "cluster-gitea-credential" "clusterorch" "$clusterGiteaPassword" "test@test2.com"
-}
-
-upgrade_gitea
-upgrade_argocd

--- a/on-prem-installers/cmd/onprem-config-installer/after-install.sh
+++ b/on-prem-installers/cmd/onprem-config-installer/after-install.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2025 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+
+# Add /usr/local/bin to the PATH as some utilities, like kubectl, could be installed there
+export PATH=$PATH:/usr/local/bin
+
+# Execute the installer with the current directory as context
+/usr/bin/onprem-config-installer

--- a/on-prem-installers/cmd/onprem-config-installer/after-remove.sh
+++ b/on-prem-installers/cmd/onprem-config-installer/after-remove.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2025 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+
+# We don't want to remove dependencies on upgrade.
+if [ "${1}" = "upgrade" ]; then
+    exit 0
+fi
+
+# disable loading of kernel modules at boot
+rm -fr /etc/modules-load.d/lv-snapshots.conf
+
+# uninstall yq
+rm -rf /usr/local/bin/yq
+
+# uninstall helm
+rm -rf /usr/local/bin/helm

--- a/on-prem-installers/cmd/onprem-config-installer/main.go
+++ b/on-prem-installers/cmd/onprem-config-installer/main.go
@@ -1,0 +1,262 @@
+// SPDX-FileCopyrightText: 2025 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"github.com/bitfield/script"
+	"github.com/magefile/mage/sh"
+)
+
+const header = `
+ ____            _                    ____             __ _
+/ ___| _   _ ___| |_ ___ _ __ ___    / ___|___  _ __  / _(_) __ _
+\___ \| | | / __| __/ _ \ '_ ' _ \  | |   / _ \| '_ \| |_| |/ _' |
+ ___) | |_| \__ \ ||  __/ | | | | | | |__| (_) | | | |  _| | (_| |
+|____/ \__, |___/\__\___|_| |_| |_|  \____\___/|_| |_|_| |_|\__, |
+       |___/                                                |___/
+`
+
+type CallbackFunc func(int64, string) (string, error)
+
+func main() {
+	fmt.Print(header)
+
+	if err := updateFanotifyFD("/etc/sysctl.conf"); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := preInstallPkg(); err != nil {
+		log.Fatal(err)
+	}
+
+	hostpathDirs := []string{"/var/openebs/local"}
+	if err := ensureHostpathDirectories(hostpathDirs); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := configModules(); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println("OnPrem OS configure completed!")
+}
+
+type BlockInfo struct {
+	Name        string      `json:"name"`
+	Size        int64       `json:"size"`
+	Type        string      `json:"type"`
+	MountPoints []string    `json:"mountpoints"`
+	Children    []BlockInfo `json:"children,omitempty"`
+}
+
+func privateCmdExcute(cmdline string) error {
+	cmd := exec.Command("/bin/sh", "-c", cmdline)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("error executing %s commands: %w", cmdline, err)
+	}
+	return nil
+}
+
+// Enable kernel modules required for LV snapshots
+func configModules() error {
+	fmt.Println("config kernel modules...")
+
+	mods, err := os.OpenFile("/etc/modules-load.d/lv-snapshots.conf", os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	defer mods.Close()
+
+	if _, err = mods.WriteString("dm-snapshot\ndm-mirror\n"); err != nil {
+		return err
+	}
+
+	if err = sh.RunV("modprobe", "dm-snapshot"); err != nil {
+		return err
+	}
+	if err = sh.RunV("modprobe", "dm-mirror"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func installYqTool(fileName string) error {
+	cmdline := "curl https://github.com/mikefarah/yq/releases/latest -s -L -I -o /dev/null -w "
+	pipe := script.NewPipe().Exec(cmdline + "'%{url_effective}'")
+	out, err := pipe.ReplaceRegexp(regexp.MustCompile(".*/"), "").String()
+	if err != nil {
+		return err
+	}
+	version := strings.ReplaceAll(out, "\n", "")
+
+	yqURL := fmt.Sprintf("https://github.com/mikefarah/yq/releases/download/%s/%s", version, fileName)
+
+	headers := make(http.Header)
+	headers.Set("User-Agent", "My-App/1.0")
+
+	if _, err = url.Parse(yqURL); err != nil {
+		return err
+	}
+
+	// Check file is exist
+	if err = os.Chdir("/tmp"); err != nil {
+		return err
+	}
+	if _, err := os.Stat(fileName); os.IsNotExist(err) {
+		fmt.Println("File does not exist")
+	} else if err != nil {
+		return err
+	} else {
+		// Delete file
+		err := os.Remove(fileName)
+		if err != nil {
+			return err
+		}
+	}
+
+	var cmdlines []string
+	cmdline = fmt.Sprintf("curl -fsSL -o /tmp/%s %s", fileName, yqURL)
+	fmt.Println(cmdline)
+	cmdlines = append(cmdlines, cmdline)
+	cmdline = fmt.Sprintf("tar xvf /tmp/%s -C /usr/local/bin", fileName)
+	cmdlines = append(cmdlines, cmdline)
+	cmdline = "mv /usr/local/bin/yq_linux_amd64 /usr/local/bin/yq"
+	cmdlines = append(cmdlines, cmdline)
+	cmdline = "chmod +x /usr/local/bin/yq"
+	cmdlines = append(cmdlines, cmdline)
+
+	for _, cmdline := range cmdlines {
+		if err := privateCmdExcute(cmdline); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func installHelmTool(fileName string, version string) error {
+	var cmdlines []string
+	helmURL := "https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3"
+
+	// Check file is exist
+	if err := os.Chdir("/tmp"); err != nil {
+		return err
+	}
+	if _, err := os.Stat(fileName); os.IsNotExist(err) {
+		fmt.Println("File does not exist")
+	} else if err != nil {
+		return err
+	} else {
+		// Delete file
+		err := os.Remove(fileName)
+		if err != nil {
+			return err
+		}
+	}
+	cmdline := fmt.Sprintf("curl -fsSL -o /tmp/%s %s", fileName, helmURL)
+	fmt.Println(cmdline)
+	cmdlines = append(cmdlines, cmdline)
+	cmdline = fmt.Sprintf("chmod 700 /tmp/%s", fileName)
+	cmdlines = append(cmdlines, cmdline)
+	cmdline = fmt.Sprintf("/tmp/%s --version %s", fileName, version)
+	cmdlines = append(cmdlines, cmdline)
+
+	for _, cmdline := range cmdlines {
+		if err := privateCmdExcute(cmdline); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func preInstallPkg() error {
+	fmt.Println("Install dependency packages...")
+
+	if err := installYqTool("yq_linux_amd64.tar.gz"); err != nil {
+		return err
+	}
+
+	return installHelmTool("get_helm.sh", "v3.12.3")
+}
+
+func writeSysctlConfig(file *os.File, found1, found2, found3 bool) error {
+	if !found1 {
+		_, err := file.WriteString("fs.inotify.max_queued_events = 1048576\n")
+		if err != nil {
+			return fmt.Errorf("writing file: %w", err)
+		}
+	}
+	if !found2 {
+		_, err := file.WriteString("fs.inotify.max_user_instances = 1048576\n")
+		if err != nil {
+			return fmt.Errorf("writing file: %w", err)
+		}
+	}
+	if !found3 {
+		_, err := file.WriteString("fs.inotify.max_user_watches = 1048576\n")
+		if err != nil {
+			return fmt.Errorf("writing file: %w", err)
+		}
+	}
+	cmdline := "sysctl -p"
+
+	return privateCmdExcute(cmdline)
+}
+
+func updateFanotifyFD(path string) error {
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0o644)
+	if err != nil {
+		return fmt.Errorf("opening file: %w", err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	found1 := false
+	found2 := false
+	found3 := false
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "#") {
+			if strings.Contains(line, "fs.inotify.max_queued_events = 1048576") {
+				found1 = true
+			}
+			if strings.Contains(line, "fs.inotify.max_user_instances = 1048576") {
+				found2 = true
+			}
+			if strings.Contains(line, "fs.inotify.max_user_watches = 1048576") {
+				found3 = true
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("scanning file:%w", err)
+	}
+
+	return writeSysctlConfig(file, found1, found2, found3)
+}
+
+// Ensure necessary directories for Hostpath
+func ensureHostpathDirectories(directories []string) error {
+	for _, dir := range directories {
+		if _, err := os.Stat(dir); os.IsNotExist(err) {
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				return fmt.Errorf("failed to create directory %s: %w", dir, err)
+			}
+		}
+	}
+	return nil
+}

--- a/on-prem-installers/cmd/onprem-config-installer/onprem-config-installer.1
+++ b/on-prem-installers/cmd/onprem-config-installer/onprem-config-installer.1
@@ -1,0 +1,18 @@
+\SPDX-FileCopyrightText: 2025 Intel Corporation
+\
+\SPDX-License-Identifier: Apache-2.0
+
+.TH INSTALLER "17" "November 2023" "onprem-config-installer 0.1.0" "User Commands"
+.SH NAME
+onprem-config-installer \- manual page for onprem-config-installer 0.1.0
+.SH DESCRIPTION
+.IP
+USAGE: onprem-config-installer
+.SH "SEE ALSO"
+.IP
+Website: https://github.com/open-edge-platform/edge-manageability-framework/on-prem-installers
+.SH "OTHER"
+.IP
+Made by Intel with ❤️
+.IP
+This program is distributed under Apache 2.0 license.

--- a/on-prem-installers/cmd/onprem-gitea/after-install.sh
+++ b/on-prem-installers/cmd/onprem-gitea/after-install.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2025 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+
+cat << "EOF"
+
+   ____ _ _
+  / ___(_) |_ ___  __ _
+ | |  _| | __/ _ \/ _` |
+ | |_| | | ||  __/ (_| |
+  \____|_|\__\___|\__,_|
+
+
+EOF
+
+IMAGE_REGISTRY="${IMAGE_REGISTRY:-docker.io}"
+
+export KUBECONFIG=/home/$USER/.kube/config
+
+# Add /usr/local/bin to the PATH as some utilities, like kubectl, could be installed there
+export PATH="$PATH:/usr/local/bin"
+
+processSAN() {
+  local result="subjectAltName=DNS:localhost"
+  for domain in "$@"; do
+    result="${result},DNS:${domain}"
+  done
+  echo "${result}"
+}
+
+processCerts() {
+  echo "Generating key..."
+
+  if ! openssl version; then
+    echo "OpenSSL not found!"
+    exit 1
+  fi
+
+  openssl="openssl"
+
+  tmpDir=$(mktemp -d)
+  $openssl genrsa -out "$tmpDir/infra-tls.key" 4096
+
+  echo "Generating certificate..."
+  san=$(processSAN "$@")
+  # Generate the certificate with the name infra-tls.crt
+  $openssl req -key "$tmpDir/infra-tls.key" -new -x509 -days 365 -out "$tmpDir/infra-tls.crt" -subj "/C=US/O=Orch Deploy/OU=Orchestrator" -addext "$san"
+  cp "${tmpDir}"/infra-tls.crt /usr/local/share/ca-certificates/gitea_cert.crt
+  update-ca-certificates
+
+  # Create a tls secret with custom key names
+  kubectl create secret tls gitea-tls-certs -n gitea \
+    --cert="$tmpDir/infra-tls.crt" \
+    --key="$tmpDir/infra-tls.key"
+
+  # Clean up the temporary directory
+  rm -rf "$tmpDir"
+}
+
+randomPassword() {
+  tr -dc A-Za-z0-9 </dev/urandom | head -c 16
+}
+
+createGiteaSecret() {
+  local secretName=$1
+  local accountName=$2
+  local password=$3
+  local namespace=$4
+
+  kubectl create secret generic "$secretName" -n "$namespace" \
+    --from-literal=username="$accountName" \
+    --from-literal=password="$password" \
+    --dry-run=client -o yaml | kubectl apply -f -
+}
+
+createGiteaAccount() {
+  local secretName=$1
+  local accountName=$2
+  local password=$3
+  local email=$4
+  local giteaPods=""
+  local giteaPod=""
+
+  giteaPods=$(kubectl get pods -n gitea -l app=gitea -o jsonpath="{.items[*].metadata.name}")
+  if [ -z "$giteaPods" ]; then
+    echo "No Gitea pods found. Exiting."
+    exit 1
+  fi
+
+  giteaPod=$(echo "$giteaPods" | cut -d ' ' -f1)
+  if ! kubectl exec -n gitea "$giteaPod" -c "gitea" -- gitea admin user list | grep -q "$accountName"; then
+    echo "Creating Gitea account for $accountName"
+    kubectl exec -n gitea "$giteaPod" -c "gitea" -- gitea admin user create --username "$accountName" --password "$password" --email "$email" --must-change-password=false
+  else
+    echo "Gitea account for $accountName already exists, updating password"
+    kubectl exec -n gitea "$giteaPod" -c "gitea" -- gitea admin user change-password --username "$accountName" --password "$password" --must-change-password=false
+  fi
+
+  userToken=$(kubectl exec -n gitea "$giteaPod" -c gitea -- gitea admin user generate-access-token --scopes write:repository,write:user --username $accountName --token-name "${accountName}-$(date +%s)")
+  token=$(echo $userToken | awk '{print $NF}')
+  kubectl create secret generic gitea-$accountName-token -n gitea --from-literal=token=$token
+}
+
+kubectl create ns gitea >/dev/null 2>&1 || true
+kubectl create ns orch-platform >/dev/null 2>&1 || true
+kubectl -n gitea get secret gitea-tls-certs >/dev/null 2>&1 || processCerts gitea-http.gitea.svc.cluster.local
+
+adminGiteaPassword=$(randomPassword)
+argocdGiteaPassword=$(randomPassword)
+appGiteaPassword=$(randomPassword)
+clusterGiteaPassword=$(randomPassword)
+
+# Create secret for Gitea admin user but should not be used for normal operations
+createGiteaSecret "gitea-cred" "gitea_admin" "$adminGiteaPassword" "gitea"
+
+# Create user credential secrets for ArgoCD, AppOrch and ClusterOrch
+createGiteaSecret "argocd-gitea-credential" "argocd" "$argocdGiteaPassword" "gitea"
+createGiteaSecret "app-gitea-credential" "apporch" "$appGiteaPassword" "orch-platform"
+createGiteaSecret "cluster-gitea-credential" "clusterorch" "$clusterGiteaPassword" "orch-platform"
+
+# More helm values are set in ../assets/gitea/values.yaml
+helm install gitea /tmp/gitea/gitea --values /tmp/gitea/values.yaml --set gitea.admin.existingSecret=gitea-cred --set image.registry="${IMAGE_REGISTRY}" -n gitea --timeout 15m0s --wait
+
+# Create Gitea accounts for ArgoCD, AppOrch and ClusterOrch
+createGiteaAccount "argocd-gitea-credential" "argocd" "$argocdGiteaPassword" "argocd@orch-installer.com"
+createGiteaAccount "app-gitea-credential" "apporch" "$appGiteaPassword" "apporch@orch-installer.com"
+createGiteaAccount "cluster-gitea-credential" "clusterorch" "$clusterGiteaPassword" "clusterorch@orch-installer.com"

--- a/on-prem-installers/cmd/onprem-gitea/after-remove.sh
+++ b/on-prem-installers/cmd/onprem-gitea/after-remove.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2025 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+
+cat << "EOF"
+
+   ____ _ _               ____
+  / ___(_) |_ ___  __ _  |  _ \ ___ _ __ ___   _____   _____
+ | |  _| | __/ _ \/ _` | | |_) / _ \ '_ ` _ \ / _ \ \ / / _ \
+ | |_| | | ||  __/ (_| | |  _ <  __/ | | | | | (_) \ V /  __/
+  \____|_|\__\___|\__,_| |_| \_\___|_| |_| |_|\___/ \_/ \___|
+
+
+EOF
+
+export KUBECONFIG=/home/$USER/.kube/config
+
+# Add /usr/local/bin to the PATH as some utilities, like kubectl, could be installed there
+export PATH=$PATH:/usr/local/bin
+
+helm delete gitea -n gitea || true
+kubectl delete secret gitea-cred gitea-tls-certs gitea-token -n gitea || true
+# clean the certificate on the system
+rm -f /usr/local/share/ca-certificates/gitea_cert.crt || true

--- a/on-prem-installers/cmd/onprem-gitea/after-upgrade.sh
+++ b/on-prem-installers/cmd/onprem-gitea/after-upgrade.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2025 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+
+cat << "EOF"
+
+   ____ _ _               _   _                           _
+  / ___(_) |_ ___  __ _  | | | |_ __   __ _ _ __ __ _  __| | ___
+ | |  _| | __/ _ \/ _` | | | | | '_ \ / _` | '__/ _` |/ _` |/ _ \
+ | |_| | | ||  __/ (_| | | |_| | |_) | (_| | | | (_| | (_| |  __/
+  \____|_|\__\___|\__,_|  \___/| .__/ \__, |_|  \__,_|\__,_|\___|
+                               |_|    |___/
+
+EOF
+
+IMAGE_REGISTRY="${IMAGE_REGISTRY:-docker.io}"
+
+export KUBECONFIG=/home/$USER/.kube/config
+
+# Add /usr/local/bin to the PATH as some utilities, like kubectl, could be installed there
+export PATH="$PATH:/usr/local/bin"
+
+processSAN() {
+  local result="subjectAltName=DNS:localhost"
+  for domain in "$@"; do
+    result="${result},DNS:${domain}"
+  done
+  echo "${result}"
+}
+
+processCerts() {
+  echo "Generating key..."
+
+  if ! openssl version; then
+    echo "OpenSSL not found!"
+    exit 1
+  fi
+
+  openssl="openssl"
+
+  tmpDir=$(mktemp -d)
+  $openssl genrsa -out "$tmpDir/infra-tls.key" 4096
+
+  echo "Generating certificate..."
+  san=$(processSAN "$@")
+  # Generate the certificate with the name infra-tls.crt
+  $openssl req -key "$tmpDir/infra-tls.key" -new -x509 -days 365 -out "$tmpDir/infra-tls.crt" -subj "/C=US/O=Orch Deploy/OU=Open Edge Platform" -addext "$san"
+  cp "${tmpDir}"/infra-tls.crt /usr/local/share/ca-certificates/gitea_cert.crt
+  update-ca-certificates
+
+  # Create a tls secret with custom key names
+  kubectl create secret tls gitea-tls-certs -n gitea \
+    --cert="$tmpDir/infra-tls.crt" \
+    --key="$tmpDir/infra-tls.key"
+
+  # Clean up the temporary directory
+  rm -rf "$tmpDir"
+}
+
+randomPassword() {
+  tr -dc A-Za-z0-9 </dev/urandom | head -c 16
+}
+
+createGiteaSecret() {
+  local secretName=$1
+  local accountName=$2
+  local password=$3
+  local namespace=$4
+
+  kubectl create secret generic "$secretName" -n "$namespace" \
+    --from-literal=username="$accountName" \
+    --from-literal=password="$password" \
+    --dry-run=client -o yaml | kubectl apply -f -
+}
+
+createGiteaAccount() {
+  local secretName=$1
+  local accountName=$2
+  local password=$3
+  local email=$4
+  local giteaPods=""
+  local giteaPod=""
+
+  giteaPods=$(kubectl get pods -n gitea -l app=gitea -o jsonpath="{.items[*].metadata.name}")
+  if [ -z "$giteaPods" ]; then
+    echo "No Gitea pods found. Exiting."
+    exit 1
+  fi
+
+  giteaPod=$(echo "$giteaPods" | cut -d ' ' -f1)
+  if ! kubectl exec -n gitea "$giteaPod" -c gitea -- gitea admin user list | grep -q "$accountName"; then
+    echo "Creating Gitea account for $accountName"
+    kubectl exec -n gitea "$giteaPod" -c gitea -- gitea admin user create --username "$accountName" --password "$password" --email "$email" --must-change-password=false
+  else
+    echo "Gitea account for $accountName already exists, updating password"
+    kubectl exec -n gitea "$giteaPod" -c gitea -- gitea admin user change-password --username "$accountName" --password "$password" --must-change-password=false
+  fi
+
+  userToken=$(kubectl exec -n gitea "$giteaPod" -c gitea -- gitea admin user generate-access-token --scopes write:repository,write:user --username "$accountName" --token-name "${accountName}-$(date +%s)")
+  token=$(echo "$userToken" | awk '{print $NF}')
+  kubectl create secret generic gitea-"$accountName"-token -n gitea --from-literal=token="$token"
+}
+
+kubectl create ns gitea >/dev/null 2>&1 || true
+kubectl create ns orch-platform >/dev/null 2>&1 || true
+kubectl -n gitea get secret gitea-tls-certs >/dev/null 2>&1 || processCerts gitea-http.gitea.svc.cluster.local
+
+adminGiteaPassword=$(randomPassword)
+argocdGiteaPassword=$(randomPassword)
+appGiteaPassword=$(randomPassword)
+clusterGiteaPassword=$(randomPassword)
+
+# Create secret for Gitea admin user but should not be used for normal operations
+createGiteaSecret "gitea-cred" "gitea_admin" "$adminGiteaPassword" "gitea"
+
+# Create user credential secrets for ArgoCD, AppOrch and ClusterOrch
+createGiteaSecret "argocd-gitea-credential" "argocd" "$argocdGiteaPassword" "gitea"
+createGiteaSecret "app-gitea-credential" "apporch" "$appGiteaPassword" "orch-platform"
+createGiteaSecret "cluster-gitea-credential" "clusterorch" "$clusterGiteaPassword" "orch-platform"
+
+# More helm values are set in ../assets/gitea/values.yaml
+helm upgrade --install gitea /tmp/gitea/gitea --values /tmp/gitea/values.yaml --set gitea.admin.existingSecret=gitea-cred --set image.registry="${IMAGE_REGISTRY}" -n gitea --timeout 15m0s --wait
+
+# Create Gitea accounts for ArgoCD, AppOrch and ClusterOrch
+createGiteaAccount "argocd-gitea-credential" "argocd" "$argocdGiteaPassword" "argocd@orch-installer.com"
+createGiteaAccount "app-gitea-credential" "apporch" "$appGiteaPassword" "test@test.com"
+createGiteaAccount "cluster-gitea-credential" "clusterorch" "$clusterGiteaPassword" "test@test2.com"

--- a/on-prem-installers/cmd/onprem-ke-installer/after-remove.sh
+++ b/on-prem-installers/cmd/onprem-ke-installer/after-remove.sh
@@ -21,12 +21,3 @@ fi
 
 # Remove artifacts
 rm -rf /tmp/onprem-ke-installer || true
-
-# disable loading of kernel modules at boot
-rm -fr /etc/modules-load.d/lv-snapshots.conf
-
-# uninstall yq
-rm -rf /usr/local/bin/yq
-
-# uninstall helm
-rm -rf /usr/local/bin/helm

--- a/on-prem-installers/cmd/onprem-ke-installer/main.go
+++ b/on-prem-installers/cmd/onprem-ke-installer/main.go
@@ -5,38 +5,21 @@
 package main
 
 import (
-	"bufio"
 	"flag"
 	"fmt"
-	"log"
-	"net/http"
-	"net/url"
 	"os"
-	"os/exec"
-	"regexp"
-	"strings"
 	"time"
 
-	"github.com/bitfield/script"
 	"github.com/open-edge-platform/edge-manageability-framework/on-prem-installers/mage"
 )
 
-const keHeader = `
+const header = `
  _  ________   _____ _   _  _____ _______       _      _      ______ _____  
 | |/ /  ____| |_   _| \ | |/ ____|__   __|/\   | |    | |    |  ____|  __ \ 
 | ' /| |__      | | |  \| | (___    | |  /  \  | |    | |    | |__  | |__) |
 |  < |  __|     | | | . | |\___ \   | | / /\ \ | |    | |    |  __| |  _  / 
 | . \| |____   _| |_| |\  |____) |  | |/ ____ \| |____| |____| |____| | \ \ 
 |_|\_\______| |_____|_| \_|_____/   |_/_/    \_\______|______|______|_|  \_\									   
-`
-
-const configHeader = `
- ____            _                    ____             __ _
-/ ___| _   _ ___| |_ ___ _ __ ___    / ___|___  _ __  / _(_) __ _
-\___ \| | | / __| __/ _ \ '_ ' _ \  | |   / _ \| '_ \| |_| |/ _' |
- ___) | |_| \__ \ ||  __/ | | | | | | |__| (_) | | | |  _| | (_| |
-|____/ \__, |___/\__\___|_| |_| |_|  \____\___/|_| |_|_| |_|\__, |
-       |___/                                                |___/
 `
 
 const (
@@ -47,7 +30,6 @@ const (
 var upgrade = flag.Bool("upgrade", false, "determine if KE should be upgraded or installed")
 
 func main() {
-	// Install RKE2 Cluster
 	if err := os.Setenv("KUBECONFIG", fmt.Sprintf("/home/%s/.kube/config", os.Getenv("USER"))); err != nil {
 		fmt.Printf("Error setting KUBECONFIG environment variable: %s\n", err)
 		os.Exit(1)
@@ -72,6 +54,7 @@ func main() {
 			os.Exit(1)
 		}
 	}
+	// --end
 
 	flag.Parse()
 	if *upgrade {
@@ -82,240 +65,10 @@ func main() {
 		os.Exit(0)
 	}
 
-	// Install System Configurations
-	if err := installSystemConfig(); err != nil {
-		log.Fatal(err)
-	}
-
 	// Deploy Online OnPrem RKE2 cluster
-	fmt.Print(keHeader)
+	fmt.Print(header)
 	if err := (mage.Deploy{}).Rke2Cluster(); err != nil {
 		fmt.Printf("Error deploying local cluster: %s\n", err)
 		os.Exit(1)
 	}
-}
-
-func installSystemConfig() error {
-	fmt.Print(configHeader)
-
-	if err := updateFanotifyFD("/etc/sysctl.conf"); err != nil {
-		return err
-	}
-
-	if err := preInstallPkg(); err != nil {
-		return err
-	}
-
-	hostpathDirs := []string{"/var/openebs/local"}
-	if err := ensureHostpathDirectories(hostpathDirs); err != nil {
-		return err
-	}
-
-	fmt.Println("OnPrem OS configure completed!")
-	return nil
-}
-
-type BlockInfo struct {
-	Name        string      `json:"name"`
-	Size        int64       `json:"size"`
-	Type        string      `json:"type"`
-	MountPoints []string    `json:"mountpoints"`
-	Children    []BlockInfo `json:"children,omitempty"`
-}
-
-func privateCmdExcute(cmdline string) error {
-	cmd := exec.Command("/bin/sh", "-c", cmdline)
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("error executing %s commands: %w", cmdline, err)
-	}
-	return nil
-}
-
-func installYqTool(fileName string) error {
-	cmdline := "curl https://github.com/mikefarah/yq/releases/latest -s -L -I -o /dev/null -w "
-	pipe := script.NewPipe().Exec(cmdline + "'%{url_effective}'")
-	out, err := pipe.ReplaceRegexp(regexp.MustCompile(".*/"), "").String()
-	if err != nil {
-		return err
-	}
-	version := strings.ReplaceAll(out, "\n", "")
-
-	yqURL := fmt.Sprintf("https://github.com/mikefarah/yq/releases/download/%s/%s", version, fileName)
-
-	headers := make(http.Header)
-	headers.Set("User-Agent", "My-App/1.0")
-
-	if _, err = url.Parse(yqURL); err != nil {
-		return err
-	}
-
-	// Save the current working directory
-	origDir, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-	// Ensure we revert to the original directory before returning
-	defer func() {
-		_ = os.Chdir(origDir)
-	}()
-
-	// Check file is exist
-	if err = os.Chdir("/tmp"); err != nil {
-		return err
-	}
-	if _, err := os.Stat(fileName); os.IsNotExist(err) {
-		fmt.Println("File does not exist")
-	} else if err != nil {
-		return err
-	} else {
-		// Delete file
-		err := os.Remove(fileName)
-		if err != nil {
-			return err
-		}
-	}
-
-	var cmdlines []string
-	cmdline = fmt.Sprintf("curl -fsSL -o /tmp/%s %s", fileName, yqURL)
-	fmt.Println(cmdline)
-	cmdlines = append(cmdlines, cmdline)
-	cmdline = fmt.Sprintf("tar xvf /tmp/%s -C /usr/local/bin", fileName)
-	cmdlines = append(cmdlines, cmdline)
-	cmdline = "mv /usr/local/bin/yq_linux_amd64 /usr/local/bin/yq"
-	cmdlines = append(cmdlines, cmdline)
-	cmdline = "chmod +x /usr/local/bin/yq"
-	cmdlines = append(cmdlines, cmdline)
-
-	for _, cmdline := range cmdlines {
-		if err := privateCmdExcute(cmdline); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func installHelmTool(fileName string, version string) error {
-	var cmdlines []string
-	helmURL := "https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3"
-
-	// Save the current working directory
-	origDir, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-	// Ensure we revert to the original directory before returning
-	defer func() {
-		_ = os.Chdir(origDir)
-	}()
-
-	// Change to /tmp
-	if err := os.Chdir("/tmp"); err != nil {
-		return err
-	}
-
-	if _, err := os.Stat(fileName); os.IsNotExist(err) {
-		fmt.Println("File does not exist")
-	} else if err != nil {
-		return err
-	} else {
-		// Delete file
-		err := os.Remove(fileName)
-		if err != nil {
-			return err
-		}
-	}
-	cmdline := fmt.Sprintf("curl -fsSL -o /tmp/%s %s", fileName, helmURL)
-	fmt.Println(cmdline)
-	cmdlines = append(cmdlines, cmdline)
-	cmdline = fmt.Sprintf("chmod 700 /tmp/%s", fileName)
-	cmdlines = append(cmdlines, cmdline)
-	cmdline = fmt.Sprintf("/tmp/%s --version %s", fileName, version)
-	cmdlines = append(cmdlines, cmdline)
-
-	for _, cmdline := range cmdlines {
-		if err := privateCmdExcute(cmdline); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func preInstallPkg() error {
-	fmt.Println("Install dependency packages...")
-
-	if err := installYqTool("yq_linux_amd64.tar.gz"); err != nil {
-		return err
-	}
-
-	return installHelmTool("get_helm.sh", "v3.12.3")
-}
-
-func writeSysctlConfig(file *os.File, found1, found2, found3 bool) error {
-	if !found1 {
-		_, err := file.WriteString("fs.inotify.max_queued_events = 1048576\n")
-		if err != nil {
-			return fmt.Errorf("writing file: %w", err)
-		}
-	}
-	if !found2 {
-		_, err := file.WriteString("fs.inotify.max_user_instances = 1048576\n")
-		if err != nil {
-			return fmt.Errorf("writing file: %w", err)
-		}
-	}
-	if !found3 {
-		_, err := file.WriteString("fs.inotify.max_user_watches = 1048576\n")
-		if err != nil {
-			return fmt.Errorf("writing file: %w", err)
-		}
-	}
-	cmdline := "sysctl -p"
-
-	return privateCmdExcute(cmdline)
-}
-
-func updateFanotifyFD(path string) error {
-	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0o644)
-	if err != nil {
-		return fmt.Errorf("opening file: %w", err)
-	}
-	defer file.Close()
-
-	scanner := bufio.NewScanner(file)
-	found1 := false
-	found2 := false
-	found3 := false
-	for scanner.Scan() {
-		line := scanner.Text()
-		if !strings.HasPrefix(line, "#") {
-			if strings.Contains(line, "fs.inotify.max_queued_events = 1048576") {
-				found1 = true
-			}
-			if strings.Contains(line, "fs.inotify.max_user_instances = 1048576") {
-				found2 = true
-			}
-			if strings.Contains(line, "fs.inotify.max_user_watches = 1048576") {
-				found3 = true
-			}
-		}
-	}
-	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("scanning file:%w", err)
-	}
-
-	return writeSysctlConfig(file, found1, found2, found3)
-}
-
-// Ensure necessary directories for Hostpath
-func ensureHostpathDirectories(directories []string) error {
-	for _, dir := range directories {
-		if _, err := os.Stat(dir); os.IsNotExist(err) {
-			if err := os.MkdirAll(dir, 0o755); err != nil {
-				return fmt.Errorf("failed to create directory %s: %w", dir, err)
-			}
-		}
-	}
-	return nil
 }

--- a/on-prem-installers/mage/Magefile.go
+++ b/on-prem-installers/mage/Magefile.go
@@ -121,6 +121,8 @@ func (b Build) All(ctx context.Context) error {
 	mg.CtxDeps(
 		ctx,
 		b.OnpremKEInstaller,
+		b.OSConfig,
+		b.GiteaInstaller,
 		b.ArgocdInstaller,
 		b.OnPremOrchInstaller,
 	)
@@ -137,6 +139,28 @@ func (b Build) OnpremKEInstaller(ctx context.Context) error {
 	)
 
 	return b.onpremKeInstaller()
+}
+
+// Build the OS-Config Installer package.
+func (b Build) OSConfig(ctx context.Context) error {
+	mg.CtxDeps(
+		ctx,
+		b.Deps,
+		mage.Deps.FPM,
+	)
+
+	return b.osConfigInstaller()
+}
+
+// Build the Gitea Installer package.
+func (b Build) GiteaInstaller(ctx context.Context) error {
+	mg.CtxDeps(
+		ctx,
+		b.Deps,
+		mage.Deps.FPM,
+	)
+
+	return b.giteaInstaller()
 }
 
 // Build the Argo-Cd Installer package.

--- a/on-prem-installers/onprem/onprem_installer.sh
+++ b/on-prem-installers/onprem/onprem_installer.sh
@@ -69,8 +69,10 @@ orch_namespace_list=(
 # Variables that depend on the above and might require updating later, are placed in here
 set_artifacts_version() {
   installer_list=(
+    "onprem-config-installer:${DEPLOY_VERSION}"
     "onprem-ke-installer:${DEPLOY_VERSION}"
     "onprem-argocd-installer:${DEPLOY_VERSION}"
+    "onprem-gitea-installer:${DEPLOY_VERSION}"
     "onprem-orch-installer:${DEPLOY_VERSION}"
   )
 
@@ -604,8 +606,12 @@ mv -f "$repo_file" "$cwd/$git_arch_name/$repo_file"
 cd "$cwd"
 rm -rf "$tmp_dir"
 
+# Run OS Configuration installer
+echo "Installing the OS level configuration..."
+eval "sudo NEEDRESTART_MODE=a DEBIAN_FRONTEND=noninteractive apt-get install -y $cwd/$deb_dir_name/onprem-config-installer_*_amd64.deb"
+echo "OS level configuration installed"
 
-# Run OS Configuration installer and K8s Installer
+# Run K8s Installer
 echo "Installing RKE2..."
 if [[ -n "${DOCKER_USERNAME}" && -n "${DOCKER_PASSWORD}" ]]; then
   echo "Docker credentials provided. Installing RKE2 with Docker credentials"
@@ -613,7 +619,7 @@ if [[ -n "${DOCKER_USERNAME}" && -n "${DOCKER_PASSWORD}" ]]; then
 else
   sudo NEEDRESTART_MODE=a DEBIAN_FRONTEND=noninteractive apt-get install -y "$cwd"/$deb_dir_name/onprem-ke-installer_*_amd64.deb
 fi
-echo "OS level configuration installed and RKE2 Installed"
+echo "RKE2 Installed"
 
 mkdir -p /home/"$USER"/.kube
 sudo cp  /etc/rancher/rke2/rke2.yaml /home/"$USER"/.kube/config
@@ -621,14 +627,17 @@ sudo chown -R "$USER":"$USER"  /home/"$USER"/.kube
 sudo chmod 600 /home/"$USER"/.kube/config
 export KUBECONFIG=/home/$USER/.kube/config
 
-
-# Run argo CD installer
-echo "Installing Gitea & ArgoCD..."
-eval "sudo NEEDRESTART_MODE=a DEBIAN_FRONTEND=noninteractive apt-get install -y $cwd/$deb_dir_name/onprem-argocd-installer_*_amd64.deb"
+# Run gitea installer
+echo "Installing Gitea"
+eval "sudo IMAGE_REGISTRY=${GITEA_IMAGE_REGISTRY} NEEDRESTART_MODE=a DEBIAN_FRONTEND=noninteractive apt-get install -y $cwd/$deb_dir_name/onprem-gitea-installer_*_amd64.deb"
 wait_for_namespace_creation $gitea_ns
 sleep 30s
 wait_for_pods_running $gitea_ns
 echo "Gitea Installed"
+
+# Run argo CD installer
+echo "Installing ArgoCD..."
+eval "sudo NEEDRESTART_MODE=a DEBIAN_FRONTEND=noninteractive apt-get install -y $cwd/$deb_dir_name/onprem-argocd-installer_*_amd64.deb"
 wait_for_namespace_creation $argo_cd_ns
 sleep 30s
 wait_for_pods_running $argo_cd_ns

--- a/on-prem-installers/onprem/uninstall_onprem.sh
+++ b/on-prem-installers/onprem/uninstall_onprem.sh
@@ -13,6 +13,7 @@ packages=(
     onprem-orch-installer
     onprem-argocd-installer
     onprem-ke-installer
+    onprem-config-installer
 )
 
 remove_package() {

--- a/terraform/orchestrator/main.tf
+++ b/terraform/orchestrator/main.tf
@@ -288,6 +288,15 @@ resource "null_resource" "copy_local_orch_installer" {
     destination = "/home/ubuntu/installers/onprem-argocd-installer_${var.deploy_tag}_amd64.deb"
   }
 
+  provisioner "file" {
+    source      = "../../${var.working_directory}/${var.local_installers_path}/onprem-config-installer_${var.deploy_tag}_amd64.deb"
+    destination = "/home/ubuntu/installers/onprem-config-installer_${var.deploy_tag}_amd64.deb"
+  }
+
+  provisioner "file" {
+    source      = "../../${var.working_directory}/${var.local_installers_path}/onprem-gitea-installer_${var.deploy_tag}_amd64.deb"
+    destination = "/home/ubuntu/installers/onprem-gitea-installer_${var.deploy_tag}_amd64.deb"
+  }
 
   provisioner "file" {
     source      = "../../${var.working_directory}/${var.local_installers_path}/onprem-ke-installer_${var.deploy_tag}_amd64.deb"


### PR DESCRIPTION
This reverts commit 2f5893046a9eb612fcda0cde535f2e42ad2d3622.

### Description

This PR reverts Consolidate on-prem-installer deb packages (#363)  because it makes changes to the `onprem_installer.sh` which are not compatible with previous releases (e.g., v3.0).  For example, if the user specifies v3.0.0 when deploying onprem, but without checking out the code assigned with that release, then installer will fail.

Given that we are creating a new installer, we can move this consolidation work as part of that effort. 

Fixes # (issue)

### Any Newly Introduced Dependencies

N/A

### How Has This Been Tested?

Locally.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
