### PR TITLE
update app-orch-catalog and nexus-api-gw for download API

### DIFF
--- a/argocd/applications/templates/app-orch-catalog.yaml
+++ b/argocd/applications/templates/app-orch-catalog.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: app/charts/{{$appName}}
-      targetRevision: 0.14.7
+      targetRevision: 0.14.8
       helm:
         releaseName: {{ $appName }}
         valuesObject:

--- a/argocd/applications/templates/nexus-api-gw.yaml
+++ b/argocd/applications/templates/nexus-api-gw.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: common/charts/nexus-api-gw
-      targetRevision: 0.1.12
+      targetRevision: 0.1.13
       helm:
         releaseName: {{$appName}}
         valuesObject:


### PR DESCRIPTION
### Description

Updates to the latest app-orch-catalog and nexus-api-gw component versions. This includes a change to support passing the Content-Type and Content-Disposition headers through nexus-api-gw in support of the new Catalog API for downloading deployment packages.

Fixes # (issue)

### Any Newly Introduced Dependencies

No.

### How Has This Been Tested?

Tested in Coder and tested with Catalog Component Tests.

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
