### PR TITLE
Remove support for older rke2 versions

### DIFF
--- a/on-prem-installers/mage/upgrade.go
+++ b/on-prem-installers/mage/upgrade.go
@@ -59,8 +59,9 @@ func (Upgrade) rke2Cluster() error {
 	/* NOTE: MINOR version cannot be skipped when upgrading Kubernetes e.g. if you're planning to go from 1.26 to 1.28,
 	   1.27 needs to be installed first.
 	   TODO: Add logic to determine version hops dynamically instead of hardcoding them.
+	   NOTE: EMF v3.0.0 uses "v1.30.10+rke2r1"
 	*/
-	for i, rke2UpgradeVersion := range []string{"v1.30.6+rke2r1", "v1.30.7+rke2r1", "v1.30.8+rke2r1", "v1.30.9+rke2r1", "v1.30.10+rke2r1"} {
+	for i, rke2UpgradeVersion := range []string{"v1.30.10+rke2r1"} {
 		// Set version in upgrade Plan and render template.
 		tmpl, err := template.ParseFiles(filepath.Join("rke2", "upgrade-plan.tmpl"))
 		if err != nil {


### PR DESCRIPTION
### Description

v3.0.0 uses v1.30.10+rke2r1. Further versions of this repo will use this rke2 version as a starting point. We don't need to upgrade from an earlier version. 

Fixes # (issue)

### Any Newly Introduced Dependencies

N/A

### How Has This Been Tested?

Locally.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
