### PR TITLE
Revert OS profiles to v0.6.2

### DIFF
--- a/argocd/applications/templates/tenancy-api-mapping.yaml
+++ b/argocd/applications/templates/tenancy-api-mapping.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: common/charts/{{$appName}}
-      targetRevision: 0.8.2
+      targetRevision: 0.9.0
       helm:
         releaseName: {{$appName}}
         valuesObject:


### PR DESCRIPTION

### Description

The change proposed in https://github.com/open-edge-platform/edge-manageability-framework/pull/515 breaks ven onboarding. This PR reverts OS profiles version.


Fixes # (issue)

### Any Newly Introduced Dependencies

None

### How Has This Been Tested?

Locally 

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
