### PR TITLE
chore: use k3s template for co-utils commands

### DIFF
--- a/mage/co_utils.go
+++ b/mage/co_utils.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	baselineClusterTemplatePath = "./node/capi/baseline.json"
-	defaultTemplate             = "baseline-v2.0.2"
+	defaultTemplate             = "baseline-k3s-v0.0.2"
 	clusterApiBaseURLTemplate   = "https://api.%s/v2/projects/%s"
 )
 
@@ -93,7 +93,7 @@ func (cu CoUtils) CreateDefaultClusterTemplate() error {
 		return fmt.Errorf("failed to create default template for project '%s': %s", project, string(body))
 	}
 
-	err = cu.SetDefaultTemplate("baseline", "v2.0.2")
+	err = cu.SetDefaultTemplate("baseline-k3s", "v0.0.2")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Description

Use baseline-k3s cluster template instead of rke2 for mage co-utils commands.

### Any Newly Introduced Dependencies

No

### How Has This Been Tested?

Tested with `mage deploy:edgeCluster dev-internal-coder-minimal`. 

```
Created cluster demo-cluster...
Waiting 15 minutes for cluster to be ready...
controlPlaneReady: false | infrastructureReady: true | Cluster Agent Status: active (2m10s)
controlPlaneReady: true  | infrastructureReady: true | Cluster Agent Status: active (2m15s)
Adding demo-cluster to kubeconfig entry...
Switched to context "demo-cluster-admin".
Waiting 5 minutes for EN Fleet Agent to start...
== Edge Cluster Pods ==
NAMESPACE             NAME                                      READY   STATUS            RESTARTS      AGE
calico-apiserver      calico-apiserver-68fdfcc849-2bsvv         0/1     Running           0             36s
calico-apiserver      calico-apiserver-68fdfcc849-t7l6k         0/1     Running           0             36s
calico-system         calico-kube-controllers-b9f9df67c-l2kzh   1/1     Running           0             34s
calico-system         calico-node-lsrkc                         0/1     PodInitializing   0             34s
calico-system         calico-typha-bcbccbd7d-g8c46              1/1     Running           0             34s
calico-system         csi-node-driver-t95nr                     2/2     Running           0             34s
calico-system         goldmane-76f67ff5f5-pcnnc                 0/1     Running           0             35s
calico-system         whisker-7f7dcbddd-gnmnf                   2/2     Terminating       0             35s
cattle-fleet-system   fleet-agent-56bdcf9dc7-f47k2              1/1     Running           0             6s
kube-system           connect-agent-host-d06172cd               1/1     Running           0             62s
kube-system           coredns-697968c856-bfnvj                  1/1     Running           0             56s
kube-system           etcd-proxy-h4h86                          0/1     Error             3 (30s ago)   56s
kube-system           helm-install-traefik-crd-jbbtj            0/1     Completed         0             56s
kube-system           helm-install-traefik-v7zrx                0/1     Completed         1             56s
kube-system           local-path-provisioner-774c6665dc-dc6j5   1/1     Running           0             56s
kube-system           metrics-server-6f4c6675d5-tt9qn           1/1     Running           0             56s
kube-system           svclb-traefik-133f76fb-zgc8v              2/2     Running           0             38s
kube-system           traefik-c98fdf6fb-ggmgf                   1/1     Running           0             38s
tigera-operator       tigera-operator-844669ff44-qxq4f          1/1     Running           0             56s

EN Fleet Agent Status: Running (5s)
Switched to context "kind-kind".
Assigned cluster labels: 
        color=blue
ENiC cluster ready 😊```

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
