### PR TITLE
Move collect diagnostics to its own action

### DIFF
--- a/.github/actions/collect_diagnostics/action.yaml
+++ b/.github/actions/collect_diagnostics/action.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+runs:
+  using: "composite"
+  steps:
+  - name: Get diagnostic information
+    id: get-diagnostic-info
+    if: always()
+    shell: bash
+    run: |
+      mkdir -p kind-diagnostics
+      kubectl get pods -o wide -A > kind-diagnostics/pods-list.txt
+      kubectl describe pods -A > kind-diagnostics/pods-describe.txt
+      mage logutils:collectArgoDiags > kind-diagnostics/argo-diag.txt
+      kubectl get applications -o yaml -A > kind-diagnostics/argocd-applications.yaml
+      kubectl get events -o yaml -A > kind-diagnostics/events.yaml
+  - name: Upload diagnostic information to CI artifact store
+    if: always()
+    uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+    with:
+      name: kind-diagnostics
+      path: |
+        kind-diagnostics/pods-list.txt
+        kind-diagnostics/pods-describe.txt
+        kind-diagnostics/argo-diag.txt
+        kind-diagnostics/argocd-applications.yaml
+        kind-diagnostics/events.yaml
+      if-no-files-found: warn

--- a/.github/actions/deploy_kind/action.yaml
+++ b/.github/actions/deploy_kind/action.yaml
@@ -98,27 +98,3 @@ runs:
       mage gen:hostfileTraefik | sudo tee -a /etc/hosts > /dev/null
       echo "Updated Hostfile entries!"
       mage gen:orchCa deploy:orchCa
-  - name: Get diagnostic information
-    id: get-diagnostic-info
-    if: always()
-    shell: bash
-    run: |
-      mkdir -p kind-diagnostics
-      kubectl get pods -o wide -A > kind-diagnostics/pods-list.txt
-      kubectl describe pods -A > kind-diagnostics/pods-describe.txt
-      mage logutils:collectArgoDiags > kind-diagnostics/argo-diag.txt
-      kubectl get applications -o yaml -A > kind-diagnostics/argocd-applications.yaml
-      kubectl get events -o yaml -A > kind-diagnostics/events.yaml
-
-  - name: Upload diagnostic information to CI artifact store
-    if: always()
-    uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
-    with:
-      name: kind-diagnostics
-      path: |
-        kind-diagnostics/pods-list.txt
-        kind-diagnostics/pods-describe.txt
-        kind-diagnostics/argo-diag.txt
-        kind-diagnostics/argocd-applications.yaml
-        kind-diagnostics/events.yaml
-      if-no-files-found: warn

--- a/.github/workflows/virtual-integration.yml
+++ b/.github/workflows/virtual-integration.yml
@@ -469,6 +469,9 @@ jobs:
           docker_password: ${{ secrets.SYS_DOCKERHUB_RO }}
           token: ${{ secrets.SYS_ORCH_GITHUB }}
           deployment_type: all
+      - name: Collect diagnostics
+        uses: ./.github/actions/collect_diagnostics
+        timeout-minutes: 15
       - name: Run policy compliance tests
         run: mage test:policyCompliance
       - name: Run image pull policy compliance tests


### PR DESCRIPTION
### Description

Move collect diagnostics to its own action to avoid being terminated by the timeout on deploy-kind.

Fixes # (issue)

### Any Newly Introduced Dependencies

N/A

### How Has This Been Tested?

CI
### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
