### PR TITLE
update app-orch-tenant-controller to 0.3.10 for harbor fix

### DIFF
--- a/argocd/applications/templates/app-orch-tenant-controller.yaml
+++ b/argocd/applications/templates/app-orch-tenant-controller.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: app/charts/{{$appName}}
-      targetRevision: 0.3.8
+      targetRevision: 0.3.10
       helm:
         releaseName: {{$appName}}
         valuesObject:


### PR DESCRIPTION
### Description

Updates to latest app-orch-tenant-controller. This fixes an incompatibility in the harbor API used by the tenant controller when provisioning fails and restarts for a project. The incompatibility was in the GetRobot Harbor API which moved from a project-scope API to a root-scope API.

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
