### PR TITLE
trusted compute feature integration for 3.1 release

### DIFF
--- a/argocd/applications/custom/app-orch-tenant-controller.tpl
+++ b/argocd/applications/custom/app-orch-tenant-controller.tpl
@@ -28,7 +28,7 @@ configProvisioner:
   releaseServiceRootUrl: oci://{{ .Values.argo.releaseService.ociRegistry }}
   {{- end}}
 
-  manifestTag: "v1.1.6"
+  manifestTag: "v1.2.0"
 
   # http proxy settings
   {{- if .Values.argo.proxy.httpProxy}}


### PR DESCRIPTION
### Description

This PR is for upgrade the cluster extension version to integrate Trusted compute changes for Open Edge Platform 3.1 release.

Fixes # (issue)
integration of EMT minimal layer for TC vm
golang upgrade
Trivy scan fixes
updates on continuous monitoring issue.
### Any Newly Introduced Dependencies

None

### How Has This Been Tested?

Sanity tests were done using TC documentation as part of release.

### Checklist:

- [ x] I agree to use the APACHE-2.0 license for my code changes
- [ x] I have not introduced any 3rd party dependency changes
- [x ] I have performed a self-review of my code
