### PR TITLE
onprem-installer to patch PXE config for onprem-oxm profile

### DIFF
--- a/.github/workflows/virtual-integration.yml
+++ b/.github/workflows/virtual-integration.yml
@@ -664,7 +664,7 @@ jobs:
       github.ref == 'refs/heads/main-pass-validation'
       )
     runs-on: ubuntu-22.04-32core-128GB
-    timeout-minutes: 120
+    timeout-minutes: 90
     env:
       KUBECONFIG: ${{ github.workspace }}/terraform/orchestrator/files/kubeconfig
     steps:
@@ -781,7 +781,7 @@ jobs:
       github.ref == 'refs/heads/main-pass-validation'
       )
     runs-on: ubuntu-22.04-16core-64GB
-    timeout-minutes: 120
+    timeout-minutes: 90
     env:
       KUBECONFIG: ${{ github.workspace }}/terraform/orchestrator/files/kubeconfig
     steps:
@@ -797,7 +797,9 @@ jobs:
           TF_VAR_no_proxy: "localhost,127.0.0.0/8,10.0.0.0/8,192.168.0.0/16,.svc,.cluster.local,.default,.internal,.orch-platform,.orch-app,.orch-cluster,.orch-infra,.orch-database,.cattle-system,.orch-secret,.onprem"
           TF_VAR_en_http_proxy: "http://192.168.99.30:8080"
           TF_VAR_en_https_proxy: "http://192.168.99.30:8080"
-          TF_VAR_overwrite_profiles: '[["profile-oxm", "argo:\n  infra-onboarding:\n    pxe-server:\n      interface: \"orchnet\"\n      bootServerIP: \"192.168.99.20\"\n      subnetAddress: \"192.168.99.0\""]]'
+          PXE_INTERFACE: "orchnet"
+          PXE_BOOT_SERVER_IP: "192.168.99.20"
+          PXE_SUBNET_ADDRESS: "192.168.99.0"
         with:
           orch_version: ${{ github.event.pull_request.head.sha }}
           orch_profile: onprem-oxm

--- a/on-prem-installers/onprem/onprem_installer.sh
+++ b/on-prem-installers/onprem/onprem_installer.sh
@@ -411,6 +411,15 @@ write_configs_using_overrides() {
     yq -i '.argo.o11y.alertingMonitor.smtp.insecureSkipVerify|=true' "$tmp_dir"/$si_config_repo/orch-configs/clusters/"$ORCH_INSTALLER_PROFILE".yaml
   fi
 
+  # Patch PXE configuration if profile is onprem-oxm
+  if [[ "$ORCH_INSTALLER_PROFILE" == "onprem-oxm" ]]; then
+    config_file="$tmp_dir/$si_config_repo/orch-configs/clusters/$ORCH_INSTALLER_PROFILE.yaml"
+    yq -i '.argo."infra-onboarding"."pxe-server".enabled = true' "$config_file"
+    yq -i '.argo."infra-onboarding"."pxe-server".interface = strenv(PXE_INTERFACE)' "$config_file"
+    yq -i '.argo."infra-onboarding"."pxe-server".bootServerIP = strenv(PXE_BOOT_SERVER_IP)' "$config_file"
+    yq -i '.argo."infra-onboarding"."pxe-server".subnetAddress = strenv(PXE_SUBNET_ADDRESS)' "$config_file"
+  fi
+
   # Override MetalLB address pools
   yq -i '.postCustomTemplateOverwrite.metallb-config.ArgoIP|=strenv(ARGO_IP)' "$tmp_dir"/$si_config_repo/orch-configs/clusters/"$ORCH_INSTALLER_PROFILE".yaml
   yq -i '.postCustomTemplateOverwrite.metallb-config.TraefikIP|=strenv(TRAEFIK_IP)' "$tmp_dir"/$si_config_repo/orch-configs/clusters/"$ORCH_INSTALLER_PROFILE".yaml


### PR DESCRIPTION
### Description

This pull request introduces a new configuration patch for PXE server settings when the `onprem-oxm` profile is used in the `on-prem-installers/onprem/onprem_installer.sh` script. 

Key change:

* Added logic to enable and configure PXE server settings (`enabled`, `interface`, `bootServerIP`, and `subnetAddress`) in the `onprem-oxm` profile by updating the corresponding YAML configuration file using `yq`. The values for these settings are sourced from environment variables (`PXE_INTERFACE`, `PXE_BOOT_SERVER_IP`, and `PXE_SUBNET_ADDRESS`).

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code