### PR TITLE
Base extension DP removal

### DIFF
--- a/argocd/applications/custom/app-orch-tenant-controller.tpl
+++ b/argocd/applications/custom/app-orch-tenant-controller.tpl
@@ -28,7 +28,7 @@ configProvisioner:
   releaseServiceRootUrl: oci://{{ .Values.argo.releaseService.ociRegistry }}
   {{- end}}
 
-  manifestTag: "v1.2.0"
+  manifestTag: "v1.3.0"
 
   # http proxy settings
   {{- if .Values.argo.proxy.httpProxy}}


### PR DESCRIPTION
### Description

Updating the TC manifest version to `1.3.0` which contains the removal of base-extension deployment package and created separate packages for cert-manager, observability, and nfd. 
Also, removed unused/not-well-maintained extensions including gatekeeper, openebs, edgedns.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Verified on latest EMF/EN

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
