### PR TITLE
update AOTC to 0.3.11 to support remove-deployment feature

### DIFF
--- a/argocd/applications/templates/app-orch-tenant-controller.yaml
+++ b/argocd/applications/templates/app-orch-tenant-controller.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: app/charts/{{$appName}}
-      targetRevision: 0.3.10
+      targetRevision: 0.3.11
       helm:
         releaseName: {{$appName}}
         valuesObject:


### PR DESCRIPTION
### Description

Adds the ability to specify "desiredState: absent" in cluster-extension manifest to cause a deployment to be removed. Intended to support removal of base-extensions deployments during upgrade.

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
