### PR TITLE
chore: switch the default template to baseline

### DIFF
--- a/argocd/applications/custom/app-orch-tenant-controller.tpl
+++ b/argocd/applications/custom/app-orch-tenant-controller.tpl
@@ -28,7 +28,7 @@ configProvisioner:
   releaseServiceRootUrl: oci://{{ .Values.argo.releaseService.ociRegistry }}
   {{- end}}
 
-  manifestTag: "v1.3.4"
+  manifestTag: "v1.3.5"
 
   # http proxy settings
   {{- if .Values.argo.proxy.httpProxy}}

--- a/argocd/applications/templates/cluster-manager.yaml
+++ b/argocd/applications/templates/cluster-manager.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: cluster/charts/{{$appName}}
-      targetRevision: 2.1.12
+      targetRevision: 2.1.13
       helm:
         releaseName: {{$appName}}
         valuesObject:
@@ -33,7 +33,7 @@ spec:
           {{- mergeOverwrite $baseConfig $customConfig $overwrite | toYaml | nindent 10 }}
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: cluster/charts/cluster-template-crd
-      targetRevision: 2.1.12
+      targetRevision: 2.1.13
   destination:
     namespace: {{$namespace}}
     server: {{ required "A valid targetServer entry required!" .Values.argo.targetServer }}


### PR DESCRIPTION
### Description

Bump cluster-manager and app tenant controller manifest version to switch the default template back to baseline as guided by SAFE.

Fixes # (issue)

https://jira.devtools.intel.com/browse/ITEP-73564

### Any Newly Introduced Dependencies

No

### How Has This Been Tested?

Yes. Tested and confirmed that the baseline template is set as default and all addons in the catalog can be deployed with it.

<img width="1411" height="791" alt="Screenshot 2025-08-04 at 10 36 44 PM" src="https://github.com/user-attachments/assets/8324c521-a74c-44f7-875f-d5b720b7f7f9" />
<img width="722" height="338" alt="image (5)" src="https://github.com/user-attachments/assets/13cd8490-b527-49e9-82b8-a3bdf6254176" />

### Checklist:

- [x ] I agree to use the APACHE-2.0 license for my code changes
- [x ] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
