### PR TITLE
update app-orch-deployment to 2.4.27

### DIFF
--- a/argocd/applications/templates/app-deployment-manager.yaml
+++ b/argocd/applications/templates/app-deployment-manager.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: app/charts/{{$appName}}
-      targetRevision: 2.4.20
+      targetRevision: 2.4.27
       helm:
         releaseName: {{$appName}}
         valuesObject:


### PR DESCRIPTION
### Description

Updates app-deployment-manager to 2.4.27. Includes the following:

* Fixes issue with DeleteSecrets failing when secrets are not found (may address github issue #644)
* Updates to Go version 1.24.6
* Removes unused AWS library
* Removes Codecommit support

### Any Newly Introduced Dependencies

No.

### How Has This Been Tested?

Tested using ADM component tests and manual coder deployment.

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
