### PR TITLE
update cluster-extensions to close kong-admin port

### DIFF
--- a/.test-dependencies.yaml
+++ b/.test-dependencies.yaml
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 test-automation:
-  version: 0.1.11
+  version: 0.1.12

--- a/argocd/applications/custom/app-orch-tenant-controller.tpl
+++ b/argocd/applications/custom/app-orch-tenant-controller.tpl
@@ -28,7 +28,7 @@ configProvisioner:
   releaseServiceRootUrl: oci://{{ .Values.argo.releaseService.ociRegistry }}
   {{- end}}
 
-  manifestTag: "v1.3.6"
+  manifestTag: "v1.3.7"
 
   # http proxy settings
   {{- if .Values.argo.proxy.httpProxy}}


### PR DESCRIPTION
### Description

Updates cluster extensions to pull in a new kubernetes-dashboard extension that disables open ports in the kong-proxy admin and api.

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
