### PR TITLE
CI updates for release-3.1

### DIFF
--- a/.github/workflows/auto-approve-merge.yml
+++ b/.github/workflows/auto-approve-merge.yml
@@ -20,7 +20,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: github.actor == github.actor == 'sys-orch' && 
-          github.event.pull_request.base.ref == 'main-pass-validation'
+          github.event.pull_request.base.ref == '3.1-pass-validation'
         run: |
           echo "Approving PR #${{ github.event.pull_request.number }} by ${{ github.actor }}"
           gh pr review ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --approve --body "Auto approved by sys-orch-github-approve bot"
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.actor == 'sys-orch' && 
-      github.event.pull_request.base.ref == 'main-pass-validation'
+      github.event.pull_request.base.ref == '3.1-pass-validation'
     steps:
       - name: Auto merge
         env:

--- a/.github/workflows/test-migration.yml
+++ b/.github/workflows/test-migration.yml
@@ -10,8 +10,7 @@ on:
   # Run on all commits that are pushed to all branches
   push:
     branches:
-      - main
-      - main-pass-validation
+      - release-3.1
 
   # Trigger workflow on PRs to all branches
   pull_request:

--- a/.github/workflows/virtual-integration.yml
+++ b/.github/workflows/virtual-integration.yml
@@ -10,8 +10,7 @@ on:
   # Run on all commits that are pushed to all branches
   push:
     branches:
-      - main
-      - main-pass-validation
+      - release-3.1
 
   # Trigger workflow on PRs to all branches
   pull_request:
@@ -114,7 +113,7 @@ jobs:
     name: Lint Markdown
     needs:
       - check-changed-files
-    if: needs.check-changed-files.outputs.markdown == 'true' ||  github.ref == 'refs/heads/main' || github.ref == 'refs/heads/main-pass-validation'
+    if: needs.check-changed-files.outputs.markdown == 'true' ||  github.ref == 'refs/heads/release-3.1'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -150,7 +149,7 @@ jobs:
     name: Lint shell scripts
     needs:
       - check-changed-files
-    if: needs.check-changed-files.outputs.shell == 'true' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/main-pass-validation'
+    if: needs.check-changed-files.outputs.shell == 'true' || github.ref == 'refs/heads/release-3.1'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -172,7 +171,7 @@ jobs:
     name: Lint Terraform
     needs:
       - check-changed-files
-    if: needs.check-changed-files.outputs.terraform == 'true' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/main-pass-validation'
+    if: needs.check-changed-files.outputs.terraform == 'true' || github.ref == 'refs/heads/release-3.1'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -193,7 +192,7 @@ jobs:
     name: Lint YAML
     needs:
       - check-changed-files
-    if: needs.check-changed-files.outputs.yaml == 'true' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/main-pass-validation'
+    if: needs.check-changed-files.outputs.yaml == 'true' || github.ref == 'refs/heads/release-3.1'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -214,7 +213,7 @@ jobs:
     name: Lint Helm
     needs:
       - check-changed-files
-    if: needs.check-changed-files.outputs.helm == 'true' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/main-pass-validation'
+    if: needs.check-changed-files.outputs.helm == 'true' || github.ref == 'refs/heads/release-3.1'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -235,7 +234,7 @@ jobs:
     name: Lint Go
     needs:
       - check-changed-files
-    if: needs.check-changed-files.outputs.go == 'true' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/main-pass-validation'
+    if: needs.check-changed-files.outputs.go == 'true' || github.ref == 'refs/heads/release-3.1'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -311,8 +310,7 @@ jobs:
       needs.check-changed-files.outputs.orch == 'true' ||
       needs.check-changed-files.outputs.on-prem == 'true' ||
       needs.check-changed-files.outputs.ci == 'true' ||
-      github.ref == 'refs/heads/main' ||
-      github.ref == 'refs/heads/main-pass-validation'
+      github.ref == 'refs/heads/release-3.1'
       )
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -413,18 +411,18 @@ jobs:
           path: trivy-orchestrator-installer-cloudfull.txt
 
       - name: Publish Cloud Installer artifact
-        if: github.event_name == 'push' && ( github.ref == 'refs/heads/main' || github.ref == 'refs/heads/main-pass-validation' )
+        if: github.event_name == 'push' && ( github.ref == 'refs/heads/release-3.1' )
         run: mage publish:cloudInstaller
 
       - name: Build release manifest artifact
-        if: github.event_name == 'push' && ( github.ref == 'refs/heads/main' || github.ref == 'refs/heads/main-pass-validation' )
+        if: github.event_name == 'push' && ( github.ref == 'refs/heads/release-3.1' )
         run: |
           mkdir -p release-manifest
           mage -v gen:releaseManifest release-manifest/chart-manifest.yaml
           mage -v gen:releaseImageManifest release-manifest/image-manifest.yaml
 
       - name: Publish release manifest artifact
-        if: github.event_name == 'push' && ( github.ref == 'refs/heads/main' || github.ref == 'refs/heads/main-pass-validation' )
+        if: github.event_name == 'push' && ( github.ref == 'refs/heads/release-3.1' )
         run: |
           mage publish:releaseManifest
 
@@ -446,8 +444,7 @@ jobs:
       needs.lint-version.result == 'success' && (
       needs.check-changed-files.outputs.orch == 'true' ||
       needs.check-changed-files.outputs.ci == 'true' ||
-      github.ref == 'refs/heads/main' ||
-      github.ref == 'refs/heads/main-pass-validation'
+      github.ref == 'refs/heads/release-3.1'
       )
     runs-on: ubuntu-24.04-16core-64GB
     timeout-minutes: 90
@@ -661,8 +658,7 @@ jobs:
       needs.check-changed-files.outputs.orch == 'true' ||
       needs.check-changed-files.outputs.on-prem == 'true' ||
       needs.check-changed-files.outputs.ci == 'true' ||
-      github.ref == 'refs/heads/main' ||
-      github.ref == 'refs/heads/main-pass-validation'
+      github.ref == 'refs/heads/release-3.1'
       )
     runs-on: ubuntu-22.04-16core-64GB
     timeout-minutes: 90
@@ -776,8 +772,7 @@ jobs:
       needs.check-changed-files.outputs.orch == 'true' ||
       needs.check-changed-files.outputs.on-prem == 'true' ||
       needs.check-changed-files.outputs.ci == 'true' ||
-      github.ref == 'refs/heads/main' ||
-      github.ref == 'refs/heads/main-pass-validation'
+      github.ref == 'refs/heads/release-3.1'
       )
     runs-on: ubuntu-22.04-16core-64GB
     timeout-minutes: 90
@@ -834,7 +829,7 @@ jobs:
       - deploy-kind
       - deploy-on-prem
       - deploy-oxm-profile
-    if: github.event_name == 'push' && ( github.ref == 'refs/heads/main' || github.ref == 'refs/heads/main-pass-validation' )
+    if: github.event_name == 'push' && ( github.ref == 'refs/heads/release-3.1' )
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -863,7 +858,7 @@ jobs:
       contents: read
       security-events: write
       id-token: write
-    if: github.event_name == 'push' && ( github.ref == 'refs/heads/main' || github.ref == 'refs/heads/main-pass-validation' )
+    if: github.event_name == 'push' && ( github.ref == 'refs/heads/release-3.1' )
     uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@e6058fe60cbb803e7d7935571ccd50753bc31ec8  # 0.1.28
     with:
       run_build: false


### PR DESCRIPTION
### Description

This pull request updates several GitHub workflow files to target the new `release-3.1` branch instead of the previous `main` and `main-pass-validation` branches. The changes ensure that automated approvals, merges, tests, and integrations are executed only for the `release-3.1` branch, aligning CI/CD processes with the new release workflow.

Branch targeting updates:

* In `.github/workflows/test-migration.yml` and `.github/workflows/virtual-integration.yml`, workflow triggers (`push` and `pull_request`) now monitor only the `release-3.1` branch, removing `main` and `main-pass-validation`. [[1]](diffhunk://#diff-e3c347f56a5c1a1c86fdaa601ca1e978324781497ceaacff3e13afa5cb0a5ac4L13-R13) [[2]](diffhunk://#diff-c115eba42a2e0ffbf4166b2a198deed597826f1299a9593c50b1bc1edd6e71c6L13-R13)

Workflow job condition updates:

* All jobs in `.github/workflows/virtual-integration.yml` that previously ran on `main` or `main-pass-validation` are now restricted to `release-3.1`, including linting, publishing artifacts, and integration tests. [[1]](diffhunk://#diff-c115eba42a2e0ffbf4166b2a198deed597826f1299a9593c50b1bc1edd6e71c6L117-R116) [[2]](diffhunk://#diff-c115eba42a2e0ffbf4166b2a198deed597826f1299a9593c50b1bc1edd6e71c6L153-R152) [[3]](diffhunk://#diff-c115eba42a2e0ffbf4166b2a198deed597826f1299a9593c50b1bc1edd6e71c6L175-R174) [[4]](diffhunk://#diff-c115eba42a2e0ffbf4166b2a198deed597826f1299a9593c50b1bc1edd6e71c6L196-R195) [[5]](diffhunk://#diff-c115eba42a2e0ffbf4166b2a198deed597826f1299a9593c50b1bc1edd6e71c6L217-R216) [[6]](diffhunk://#diff-c115eba42a2e0ffbf4166b2a198deed597826f1299a9593c50b1bc1edd6e71c6L238-R237) [[7]](diffhunk://#diff-c115eba42a2e0ffbf4166b2a198deed597826f1299a9593c50b1bc1edd6e71c6L314-R313) [[8]](diffhunk://#diff-c115eba42a2e0ffbf4166b2a198deed597826f1299a9593c50b1bc1edd6e71c6L416-R425) [[9]](diffhunk://#diff-c115eba42a2e0ffbf4166b2a198deed597826f1299a9593c50b1bc1edd6e71c6L449-R447) [[10]](diffhunk://#diff-c115eba42a2e0ffbf4166b2a198deed597826f1299a9593c50b1bc1edd6e71c6L664-R661) [[11]](diffhunk://#diff-c115eba42a2e0ffbf4166b2a198deed597826f1299a9593c50b1bc1edd6e71c6L779-R775) [[12]](diffhunk://#diff-c115eba42a2e0ffbf4166b2a198deed597826f1299a9593c50b1bc1edd6e71c6L837-R832) [[13]](diffhunk://#diff-c115eba42a2e0ffbf4166b2a198deed597826f1299a9593c50b1bc1edd6e71c6L866-R861)

These updates ensure that CI/CD automation is focused on the correct release branch, preventing jobs from running on outdated or unintended branches.


Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
