### PR TITLE
Fix skip kind and onprem VIP jobs if only design proposal changes

### DIFF
--- a/.github/workflows/virtual-integration.yml
+++ b/.github/workflows/virtual-integration.yml
@@ -80,12 +80,16 @@ jobs:
         run: |
           files="${{ steps.check-files.outputs.changed_files }}"
           only_design=true
-          for file in $(echo $files | tr ',' '\n'); do
+          # Remove brackets and quotes, then split on comma
+          clean_files=$(echo "$files" | sed 's/\[//;s/\]//;s/"//g')
+          for file in $(echo "$clean_files" | tr ',' '\n'); do
+            file=$(echo $file | xargs) # trim whitespace
             if [[ $file != design-proposals/* ]]; then
               only_design=false
               break
             fi
           done
+          echo "only_design=$only_design"
           echo "only_design_proposals=$only_design" >> $GITHUB_OUTPUT
 
   scan-viruses:


### PR DESCRIPTION
### Description

This pull request updates the workflow logic in `.github/workflows/virtual-integration.yml` to improve how changed files are processed for the "only design proposals" check. The most important change is a more robust method for cleaning and splitting the list of changed files before evaluating them.

Workflow logic improvements:

* Improved parsing of the `changed_files` output by removing brackets and quotes and trimming whitespace from each filename to ensure accurate file matching. (`.github/workflows/virtual-integration.yml`)
* Added an explicit debug output line to print the value of `only_design` for easier troubleshooting. (`.github/workflows/virtual-integration.yml`)

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
