### PR TITLE
Disable delete protection on traefik3 nlb

### DIFF
--- a/pod-configs/utils/provision.sh
+++ b/pod-configs/utils/provision.sh
@@ -1391,6 +1391,11 @@ disable_lb_protect() {
         aws elbv2 modify-load-balancer-attributes --load-balancer-arn $traefik2_lb_arn --attributes "Key=deletion_protection.enabled,Value=false" --region "${AWS_REGION}" > /dev/null
         lb_created=true
     fi
+    traefik3_lb_arn=$(jq -r '.resources[] | select((.module == "module.traefik3_load_balancer[0]") and (.type == "aws_lb")) | .instances[0].attributes.arn' $outfile)
+    if [[ -n "$traefik3_lb_arn" ]]; then
+        aws elbv2 modify-load-balancer-attributes --load-balancer-arn $traefik3_lb_arn --attributes "Key=deletion_protection.enabled,Value=false" --region "${AWS_REGION}" > /dev/null
+        lb_created=true
+    fi
     argocd_lb_arn=$(jq -r '.resources[] | select((.module == "module.argocd_load_balancer[0]") and (.type == "aws_lb")) | .instances[0].attributes.arn' $outfile)
     if [[ -n "$argocd_lb_arn" ]]; then
         aws elbv2 modify-load-balancer-attributes --load-balancer-arn $argocd_lb_arn --attributes "Key=deletion_protection.enabled,Value=false" --region "${AWS_REGION}" > /dev/null


### PR DESCRIPTION
### Description

Delete protection should be disabled on the newly added nlb when running destroy. 

If this is not disabled, the uninstall fails to destroy this resource. 

Fixes # (issue)

### Any Newly Introduced Dependencies

n/a

### How Has This Been Tested?

Manual check.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
