### PR TITLE
update app orch component

### DIFF
--- a/argocd/applications/templates/app-deployment-crd.yaml
+++ b/argocd/applications/templates/app-deployment-crd.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: app/charts/{{$appName}}
-      targetRevision: 2.4.20
+      targetRevision: 2.5.0
       helm:
         releaseName: {{$appName}}
         valuesObject:

--- a/argocd/applications/templates/app-deployment-manager.yaml
+++ b/argocd/applications/templates/app-deployment-manager.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: app/charts/{{$appName}}
-      targetRevision: 2.4.27
+      targetRevision: 2.5.0
       helm:
         releaseName: {{$appName}}
         valuesObject:

--- a/argocd/applications/templates/app-interconnect-manager.yaml
+++ b/argocd/applications/templates/app-interconnect-manager.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: app/charts/{{$appName}}
-      targetRevision: 0.1.18
+      targetRevision: 0.3.0
       helm:
         releaseName: {{$appName}}
         valuesObject:

--- a/argocd/applications/templates/app-resource-manager.yaml
+++ b/argocd/applications/templates/app-resource-manager.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: app/charts/{{$appName}}
-      targetRevision: 2.4.4
+      targetRevision: 2.5.0
       helm:
         releaseName: {{$appName}}
         valuesObject:

--- a/argocd/applications/templates/app-service-proxy.yaml
+++ b/argocd/applications/templates/app-service-proxy.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: app/charts/{{$appName}}
-      targetRevision: 1.4.4
+      targetRevision: 1.5.0
       helm:
         releaseName: {{$appName}}
         valuesObject:


### PR DESCRIPTION
### Description

These updated versions of app-orch-deployment components contains changes related to migration of openapi tool generation to protoc-gen-connect-openapi for apiv2.

PR include:

app-deployment-crd.yaml: 2.5.0
app-deployment-manager.yaml: 2.5.0
app-interconnect-manager.yaml: 0.3.0
app-resource-manager.yaml: 2.5.0
app-service-proxy.yaml: 1.5.0

### How Has This Been Tested?

changes has been validated in coder environment

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
