### PR TITLE
DO NOT MERGE: Migrate kubectl image from bitnamilegacy to alpine

### DIFF
--- a/argocd/applications/custom/app-deployment-manager.tpl
+++ b/argocd/applications/custom/app-deployment-manager.tpl
@@ -19,6 +19,12 @@ image:
     {{- end }}
 
 adm:
+{{- if .Values.argo.proxy.httpsProxy}}
+  httpsProxy: {{.Values.argo.proxy.httpsProxy}}
+{{- end}}
+{{- if .Values.argo.proxy.noProxy}}
+  noProxy: {{.Values.argo.proxy.noProxy}}
+{{- end}}
   gitProxy: {{ .Values.argo.git.gitProxy }}
 {{- if .Values.argo.git.gitServer }}
   gitServer: {{ .Values.argo.git.gitServer }}


### PR DESCRIPTION
### Description

This PR includes the changes that are needed in the EMF repo so that we can migrate the kubectl image from bitnamilegacy to the alpine one.


Fixes # (issue)

### Any Newly Introduced Dependencies

n/a

### How Has This Been Tested?

locally/ci

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
