### PR TITLE
Migrate kyverno kubectl images used in the cleanup controllers from bitnamilegacy to eclipsefdn

### DIFF
--- a/argocd/applications/configs/kyverno.yaml
+++ b/argocd/applications/configs/kyverno.yaml
@@ -3,7 +3,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 webhooksCleanup:
-  image: alpine/kubectl:1.34.1
+  image:
+    registry: docker.io
+    repository: alpine/kubectl
+    tag: 1.34.1
+policyReportCleanup:
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/kubectl
+    tag: 1.28.4
 
 cleanupJobs:
   admissionReports:
@@ -22,6 +30,11 @@ cleanupJobs:
       repository: alpine/kubectl
       tag: 1.34.1
   ephemeralReports:
+    image:
+      registry: docker.io
+      repository: alpine/kubectl
+      tag: 1.34.1
+  updateRequests:
     image:
       registry: docker.io
       repository: alpine/kubectl

--- a/argocd/applications/configs/kyverno.yaml
+++ b/argocd/applications/configs/kyverno.yaml
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+webhooksCleanup:
+  image: alpine/kubectl:1.34.1
 
 cleanupJobs:
   admissionReports:

--- a/argocd/applications/configs/kyverno.yaml
+++ b/argocd/applications/configs/kyverno.yaml
@@ -5,40 +5,61 @@
 webhooksCleanup:
   image:
     registry: docker.io
-    repository: alpine/kubectl
-    tag: 1.34.1
+    repository: eclipsefdn/kubectl
+    tag: okd-c1
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1001
 policyReportCleanup:
   image:
     registry: docker.io
-    repository: bitnamilegacy/kubectl
-    tag: 1.28.4
+    repository: eclipsefdn/kubectl
+    tag: okd-c1
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1001
 
 cleanupJobs:
   admissionReports:
     image:
       registry: docker.io
-      repository: alpine/kubectl
-      tag: 1.34.1
+      repository: eclipsefdn/kubectl
+      tag: okd-c1
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1001
   clusterAdmissionReports:
     image:
       registry: docker.io
-      repository: alpine/kubectl
-      tag: 1.34.1
+      repository: eclipsefdn/kubectl
+      tag: okd-c1
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1001
   clusterEphemeralReports:
     image:
       registry: docker.io
-      repository: alpine/kubectl
-      tag: 1.34.1
+      repository: eclipsefdn/kubectl
+      tag: okd-c1
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1001
   ephemeralReports:
     image:
       registry: docker.io
-      repository: alpine/kubectl
-      tag: 1.34.1
+      repository: eclipsefdn/kubectl
+      tag: okd-c1
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1001
   updateRequests:
     image:
       registry: docker.io
-      repository: alpine/kubectl
-      tag: 1.34.1
+      repository: eclipsefdn/kubectl
+      tag: okd-c1
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1001
 
 # Deploy minimally viable HA config. See https://kyverno.io/docs/installation/methods/#high-availability
 admissionController:


### PR DESCRIPTION
### Description


This PR changes kyverno kubectl images used in the cleanup controllers from bitnamilegacy to eclipsefdn

Fixes # (issue)

### Any Newly Introduced Dependencies

n/a

### How Has This Been Tested?

ci.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
