### PR TITLE
Migrate kyverno images from bitnami to bitnamilegay

### DIFF
--- a/argocd/applications/configs/kyverno.yaml
+++ b/argocd/applications/configs/kyverno.yaml
@@ -2,6 +2,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+webhooksCleanup:
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/kubectl
+    tag: 1.28.5
+policyReportCleanup:
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/kubectl
+    tag: 1.28.5
 
 cleanupJobs:
   admissionReports:
@@ -20,6 +30,11 @@ cleanupJobs:
       repository: bitnamilegacy/kubectl
       tag: 1.28.5
   ephemeralReports:
+    image:
+      registry: docker.io
+      repository: bitnamilegacy/kubectl
+      tag: 1.28.5
+  updateRequests:
     image:
       registry: docker.io
       repository: bitnamilegacy/kubectl

--- a/argocd/applications/configs/secret-wait-tls-boots.yaml
+++ b/argocd/applications/configs/secret-wait-tls-boots.yaml
@@ -6,4 +6,4 @@ secretName: "tls-boots"
 resources: null
 
 secret-wait:
-  image: "bitnamilegacy/kubectl:1.28.4"
+  image: bitnamilegacy/kubectl:1.28.5

--- a/argocd/applications/configs/secret-wait-tls-orch.yaml
+++ b/argocd/applications/configs/secret-wait-tls-orch.yaml
@@ -6,4 +6,4 @@ secretName: "tls-orch"
 resources: null
 
 secret-wait:
-  image: "bitnamilegacy/kubectl:1.28.4"
+  image: bitnamilegacy/kubectl:1.28.5


### PR DESCRIPTION
### Description

Migrate updateRequests, webhooksCleanup and policyReportCleanup to use bitnamilegacy images.

Fixes # (issue)

### Any Newly Introduced Dependencies

n/a

### How Has This Been Tested?

ci

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
