### PR TITLE
Migrate keycloakConfigCli from bitnami to bitnamilegacy

### DIFF
--- a/argocd/applications/configs/platform-keycloak.yaml
+++ b/argocd/applications/configs/platform-keycloak.yaml
@@ -62,6 +62,12 @@ extraStartupArgs: >-
 ## ref: https://github.com/adorsys/keycloak-config-cli
 ##
 keycloakConfigCli:
+  image:
+    pullPolicy: IfNotPresent
+    registry: docker.io
+    repository: bitnamilegacy/keycloak-config-cli
+    tag: 6.4.0-debian-12-r0
+
   ## @param keycloakConfigCli.enabled Whether to enable keycloak-config-cli job
   ##
   enabled: true


### PR DESCRIPTION
### Description

This PR migrates keycloakConfigCli  from bitnami to bitnamilegacy.


Fixes # (issue)

### Any Newly Introduced Dependencies

N/A

### How Has This Been Tested?

ci/locally

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
