### PR TITLE
feat: setup m2m service account in Keycloak for cluster-orch

### DIFF
--- a/argocd/applications/configs/platform-keycloak.yaml
+++ b/argocd/applications/configs/platform-keycloak.yaml
@@ -232,6 +232,7 @@ keycloakConfigCli:
           "client": {
             "alerts-m2m-client": [],
             "host-manager-m2m-client": [],
+            "co-manager-m2m-client": [],
             "ktc-m2m-client": [],
             "3rd-party-host-manager-m2m-client": [],
             "edge-manager-m2m-client": [],
@@ -367,6 +368,45 @@ keycloakConfigCli:
               "phone",
               "offline_access",
               "microprofile-jwt"
+            ]
+          },
+          {
+            "clientId": "co-manager-m2m-client",
+            "name": "Cluster Orchestrator Manager M2M Client",
+            "description": "Client for cluster-manager to access Keycloak for JWT TTL management",
+            "surrogateAuthRequired": false,
+            "enabled": true,
+            "alwaysDisplayInConsole": false,
+            "clientAuthenticatorType": "client-secret",
+            "notBefore": 0,
+            "bearerOnly": false,
+            "consentRequired": false,
+            "standardFlowEnabled": false,
+            "implicitFlowEnabled": false,
+            "directAccessGrantsEnabled": false,
+            "serviceAccountsEnabled": true,
+            "authorizationServicesEnabled": true,
+            "publicClient": false,
+            "frontchannelLogout": true,
+            "protocol": "openid-connect",
+            "attributes": {
+              "oidc.ciba.grant.enabled": "false",
+              "oauth2.device.authorization.grant.enabled": "false",
+              "backchannel.logout.session.required": "true",
+              "backchannel.logout.revoke.offline.tokens": "false"
+            },
+            "fullScopeAllowed": true,
+            "defaultClientScopes": [
+              "web-origins",
+              "acr",
+              "profile",
+              "roles",
+              "email",
+              "basic",
+              "groups"
+            ],
+            "optionalClientScopes": [
+              "offline_access"
             ]
           },
           {
@@ -1096,6 +1136,29 @@ keycloakConfigCli:
               ]
             },
             "notBefore": 0
+          },
+          {
+            "username": "service-account-co-manager-m2m-client",
+            "enabled": true,
+            "totp": false,
+            "serviceAccountClientId": "co-manager-m2m-client",
+            "realmRoles": [
+              "default-roles-master"
+            ],
+            "clientRoles": {
+              "co-manager-m2m-client": [
+                "uma_protection"
+              ],
+              "master-realm": [
+                "view-clients",
+                "manage-clients"
+              ]
+            },
+            "notBefore": 0,
+            "groups": [
+              "/edge-manager-group",
+              "/apps-m2m-service-account"
+            ]
           },
           {
             "username": "service-account-ktc-m2m-client",


### PR DESCRIPTION
### Description

This setup for a machine-to-machine service account client configuration for the keycloak platform. This will allow Cluster-manager to configure the JWT TTL values for the downstream cluster kubeconfig.

Fixes # (issue)
[ITEP-77807](https://jira.devtools.intel.com/browse/ITEP-77807)

### Any Newly Introduced Dependencies

none

### How Has This Been Tested?

So far, just the new client creation was verified in Keycloak without regression (cluster creation/deletion)


### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
