### PR TITLE
Add support for configurable memory for health check service

### DIFF
--- a/argocd/applications/custom/infra-onboarding.tpl
+++ b/argocd/applications/custom/infra-onboarding.tpl
@@ -48,6 +48,7 @@ infra-config:
     orchDeviceManager: device-manager-node.{{ .Values.argo.clusterDomain }}:443
 
     rsType: "{{ index .Values.argo "infra-onboarding" "rsType" | default "no-auth" }}"
+    maxAgentMemory: "{{ index .Values.argo "infra-onboarding" "maxAgentMemory" | default "128M" }}"
     netIp: "{{ index .Values.argo "infra-onboarding" "netIp" | default "dynamic" }}"
     ntpServer: "{{ index .Values.argo "infra-onboarding" "ntpServer" | default "ntp1.server.org,ntp2.server.org" }}"
     {{- $nameServers := index .Values.argo "infra-onboarding" "nameServers" | default list }}

--- a/argocd/applications/templates/infra-onboarding.yaml
+++ b/argocd/applications/templates/infra-onboarding.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: infra/charts/{{$appName}}
-      targetRevision: 1.33.7
+      targetRevision: 1.33.10
       helm:
         releaseName: {{$appName}}
         valuesObject:


### PR DESCRIPTION
### Description

Updates the cloud-init to allow for configuration of the MemoryMax setting in the platform-observability-health-check service on the edge node to a non-default value.

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
