### PR TITLE
Revert "added ~ chracter as prefix in os-profile revision to support dynamic addition of os-profile patched versions #804"

### DIFF
--- a/argocd/applications/configs/infra-managers.yaml
+++ b/argocd/applications/configs/infra-managers.yaml
@@ -69,7 +69,7 @@ telemetry-manager:
 
 os-resource-manager:
   managerArgs:
-    osProfileRevision: ~0.8.2
+    osProfileRevision: 0.8.2
     osSecurityFeatureEnable: false
     inventoryAddress: "inventory.orch-infra.svc.cluster.local:50051"
     traceURL: "orchestrator-observability-opentelemetry-collector.orch-platform.svc:4318"

--- a/argocd/applications/templates/infra-managers.yaml
+++ b/argocd/applications/templates/infra-managers.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: infra/charts/{{$appName}}
-      targetRevision: 2.15.2
+      targetRevision: 2.15.1
       helm:
         releaseName: {{$appName}}
         valuesObject:


### PR DESCRIPTION
This reverts commit [abd2980](https://github.com/open-edge-platform/edge-manageability-framework/pull/910/commits/abd298087aefe6317476ee367ae040c45bb1dbee).


### Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
