### PR TITLE
Enable startup probe in gitea

### DIFF
--- a/bootstrap/gitea.yaml
+++ b/bootstrap/gitea.yaml
@@ -73,6 +73,8 @@ service:
     type: LoadBalancer
     port: 443
 gitea:
+  startupProbe:
+    enabled: true
   config:
     server:
       APP_DATA_PATH: /data

--- a/on-prem-installers/assets/gitea/values.yaml
+++ b/on-prem-installers/assets/gitea/values.yaml
@@ -110,6 +110,8 @@ persistence:
   storageClass: "openebs-hostpath"
 
 gitea:
+  startupProbe:
+    enabled: true
   config:
     database:
       DB_TYPE: postgres

--- a/orch-configs/templates/bootstrap/gitea.tpl
+++ b/orch-configs/templates/bootstrap/gitea.tpl
@@ -76,6 +76,8 @@ service:
     type: LoadBalancer
     port: 443
 gitea:
+  startupProbe:
+    enabled: true
   config:
     server:
       APP_DATA_PATH: /data

--- a/pod-configs/module/gitea/gitea-values.yaml.tpl
+++ b/pod-configs/module/gitea/gitea-values.yaml.tpl
@@ -86,6 +86,8 @@ service:
     port: 443
     clusterIP: ""
 gitea:
+  startupProbe:
+    enabled: true
   admin:
     password: ${gitea_password}
     passwordMode: initialOnlyNoReset


### PR DESCRIPTION
### Description

This PR enables the startup probe in gitea. The startup probe checks if the application is ready before proceeding. This temporarily disables livenessProbe and readinessProbe. This is needed as gitea deployment sometimes fails in the CI.


Fixes # (issue)

### Any Newly Introduced Dependencies
n/a

### How Has This Been Tested?

ci
### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
