### PR TITLE
Pin osProfileRevision to 0.8.7

### DIFF
--- a/argocd/applications/configs/infra-managers.yaml
+++ b/argocd/applications/configs/infra-managers.yaml
@@ -69,7 +69,7 @@ telemetry-manager:
 
 os-resource-manager:
   managerArgs:
-    osProfileRevision: ~0.8.7
+    osProfileRevision: 0.8.7
     osSecurityFeatureEnable: false
     inventoryAddress: "inventory.orch-infra.svc.cluster.local:50051"
     traceURL: "orchestrator-observability-opentelemetry-collector.orch-platform.svc:4318"


### PR DESCRIPTION
### Description

Pin the osProfileRevision to 0.8.7 instead of using a reg ex which causes stability issues.

Fixes # (issue)

### Any Newly Introduced Dependencies

n/a

### How Has This Been Tested?

ci

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
