### PR TITLE
Update gitea rootless image to 1.25.1

### DIFF
--- a/bootstrap/gitea.yaml
+++ b/bootstrap/gitea.yaml
@@ -5,7 +5,7 @@
 image:
   pullPolicy: IfNotPresent
   rootless: true
-  tag: 1.25.0
+  tag: 1.25.1
 containerSecurityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/on-prem-installers/assets/gitea/values.yaml
+++ b/on-prem-installers/assets/gitea/values.yaml
@@ -137,8 +137,7 @@ gitea:
       CERT_FILE: /tmp/secret-volume/tls.crt
       KEY_FILE: /tmp/secret-volume/tls.key
 image:
-  rootless: true
-  tag: 1.25.0
+  tag: 1.25.1
 
 service:
   http:

--- a/orch-configs/templates/bootstrap/gitea.tpl
+++ b/orch-configs/templates/bootstrap/gitea.tpl
@@ -8,7 +8,7 @@ image:
 {{- end }}
   pullPolicy: IfNotPresent
   rootless: true
-  tag: 1.25.0
+  tag: 1.25.1
 containerSecurityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/pod-configs/module/gitea/gitea-values.yaml.tpl
+++ b/pod-configs/module/gitea/gitea-values.yaml.tpl
@@ -7,7 +7,7 @@ global:
 image:
   pullPolicy: IfNotPresent
   rootless: true
-  tag: 1.25.0
+  tag: 1.25.1
 containerSecurityContext:
   allowPrivilegeEscalation: false
   capabilities:


### PR DESCRIPTION
### Description

This PR updates the image tag used in the gitea helm chart to 1.25.1.


Fixes # (issue)

### Any Newly Introduced Dependencies

n/a

### How Has This Been Tested?

ci

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
