### PR TITLE
Changing syncwave to run after EIM tenant controller

### DIFF
--- a/argocd/applications/templates/tenancy-init.yaml
+++ b/argocd/applications/templates/tenancy-init.yaml
@@ -4,7 +4,7 @@
 
 {{- $appName        := "tenancy-init" }}
 {{- $namespace      := "orch-iam" }}
-{{- $syncWave       := "1200" }}
+{{- $syncWave       := "3000" }}
 ---
 {{- if and (index .Values.argo.enabled "multitenant_gateway") (index .Values.argo.enabled "defaultTenancy") }}
 apiVersion: argoproj.io/v1alpha1


### PR DESCRIPTION
### Description

This change is brought to allow the tenancy-init job to be run after the EIM Tenant Controller is run so that the projectactivewatcher for EdgeInfraTenantController is created on project creation and the tenant-admin user is able to see the list of os profiles upon request. 

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
