### PR TITLE
chore: bump CAPINTEL version

### DIFF
--- a/argocd/applications/templates/intel-infra-provider.yaml
+++ b/argocd/applications/templates/intel-infra-provider.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: cluster/charts/{{$appName}}
-      targetRevision: 1.3.0
+      targetRevision: 1.3.1
       helm:
         releaseName: {{$appName}}
         valuesObject:
@@ -33,7 +33,7 @@ spec:
           {{- mergeOverwrite $baseConfig $customConfig $overwrite | toYaml | nindent 10 }}
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: cluster/charts/intel-infra-provider-crds
-      targetRevision: 1.3.0
+      targetRevision: 1.3.1
   destination:
     namespace: {{$namespace}}
     server: {{ required "A valid targetServer entry required!" .Values.argo.targetServer }}


### PR DESCRIPTION
### Description

Bump cluster-api-provider-intel chart version to address cluster creation failure due to old inventory version.

Fixes # (issue)
- https://github.com/open-edge-platform/cluster-api-provider-intel/pull/224

### Any Newly Introduced Dependencies

No

### How Has This Been Tested?

Coder + XR-12

<img width="1552" height="1224" alt="Screenshot 2025-11-24 at 9 17 26 PM" src="https://github.com/user-attachments/assets/6ce1c59b-ecd4-484c-b30d-479f0b5a5644" />
<img width="1552" height="1224" alt="Screenshot 2025-11-24 at 9 17 29 PM" src="https://github.com/user-attachments/assets/a51047ff-b717-491c-b38f-cbd0f6a08354" />

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
