### PR TITLE
Update kube-prometheus-stack chart to 79.7.1

### DIFF
--- a/argocd/applications/configs/alerting-monitor.yaml
+++ b/argocd/applications/configs/alerting-monitor.yaml
@@ -20,4 +20,5 @@ traefikApiGroup: "traefik.io/v1alpha1"
 
 alertmanager:
   configmapReload:
-    tag: v0.86.2
+    image:
+      tag: v0.86.2

--- a/argocd/applications/templates/alerting-monitor.yaml
+++ b/argocd/applications/templates/alerting-monitor.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: o11y/charts/{{$appName}}
-      targetRevision: 1.7.3
+      targetRevision: 1.7.4
       helm:
         releaseName: {{$appName}}
         valuesObject:

--- a/argocd/applications/templates/orchestrator-prometheus-agent.yaml
+++ b/argocd/applications/templates/orchestrator-prometheus-agent.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: https://prometheus-community.github.io/helm-charts
       chart: kube-prometheus-stack
-      targetRevision: 69.3.2
+      targetRevision: 79.7.1
       helm:
         releaseName: {{$appName}}
         valuesObject:


### PR DESCRIPTION
### Description

This PR updates the prometheus stack chart to 79.7.1.

Also this PR fixes prometheus updates in other charts.

Fixes # (issue)

### Any Newly Introduced Dependencies

n/a

### How Has This Been Tested?

ci and locally

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
