### PR TITLE
On-Prem upgrade is compatible with the 2025.02 latest release

### DIFF
--- a/on-prem-installers/onprem/after_upgrade_restart.sh
+++ b/on-prem-installers/onprem/after_upgrade_restart.sh
@@ -467,7 +467,7 @@ sync_not_green_apps_once() {
             echo "$(yellow)[INFO] Attempt ${attempt}/${APP_MAX_RETRIES}, elapsed: 0s$(reset)"
 
             # Check if app requires server-side apply and special cleanup
-            if [[ " $SERVER_SIDE_APPS " =~ " $name " ]]; then
+            if [[ " $SERVER_SIDE_APPS " =~ \ $name\  ]]; then
                 echo "$(yellow)[INFO] Stopping any ongoing operations for $name before force sync...$(reset)"
                 argocd app terminate-op "$full_app" --grpc-web 2>/dev/null || true
                 sleep 2
@@ -796,7 +796,7 @@ sync_all_apps_exclude_root() {
             echo "$(yellow)[INFO] Attempt ${attempt}/${APP_MAX_RETRIES}, elapsed: 0s$(reset)"
 
             # Check if app requires server-side apply and special cleanup
-            if [[ " $SERVER_SIDE_APPS " =~ " $name " ]]; then
+            if [[ " $SERVER_SIDE_APPS " =~ \ $name\  ]]; then
                 echo "$(yellow)[INFO] Stopping any ongoing operations for $name before force sync...$(reset)"
                 argocd app terminate-op "$full_app" --grpc-web 2>/dev/null || true
                 sleep 2
@@ -1251,7 +1251,8 @@ post_upgrade_cleanup() {
     kubectl delete secret tls-boots -n orch-boots || true
     kubectl delete secret boots-ca-cert -n orch-gateway || true
     kubectl delete secret boots-ca-cert -n orch-infra || true
-
+    echo "[INFO] Waiting 30 seconds for secrets cleanup to complete before deleting dkam pods..."
+    sleep 30
     echo "[INFO] Deleting dkam pods in namespace orch-infra..."
     kubectl delete pod -n orch-infra -l app.kubernetes.io/name=dkam 2>/dev/null || true
 
@@ -1265,13 +1266,7 @@ execute_full_sync() {
     sync_until_green_ns_exclude_root
     print_header "Syncing root-app after all other apps are green"
     sync_root_app_only
-
     post_upgrade_cleanup
-
-    sleep 60
-    print_header "Post-upgrade: Syncing all apps (excluding root-app) again"
-    sync_all_apps_exclude_root
-    print_header "Post-upgrade: Syncing root-app again"
     sync_root_app_only
 }
 

--- a/on-prem-installers/onprem/onprem_upgrade.sh
+++ b/on-prem-installers/onprem/onprem_upgrade.sh
@@ -8,7 +8,10 @@
 # Description: This script:
 #               If requested - does a backup of PVs and cluster's ETCD
 #               Downloads debian packages and repo artifacts,
-#               Upgrades packages to v3.1.0:
+#               Upgrades packages from either:
+#                 - v3.1.3 to latest (set -u true or omit, default)
+#                 - v2025.02 to latest (set -u false)
+#               Upgrades:
 #                 - OS config,
 #                 - RKE2 and basic cluster components,
 #                 - ArgoCD,
@@ -18,6 +21,7 @@
 # Usage: ./onprem_upgrade
 #    -o:             Override production values with dev values
 #    -b:             enable backup of Orchestrator PVs before upgrade (optional)
+#    -u [true|false]: specify source version: true=from 3.1.3 (default), false=from 2025.02
 #    -h:             help (optional)
 
 set -e
@@ -77,7 +81,8 @@ ORCH_INSTALLER_PROFILE="${ORCH_INSTALLER_PROFILE:-onprem}"
 DEPLOY_VERSION="${DEPLOY_VERSION:-v3.1.0}"  # Updated to v3.1.0
 GITEA_IMAGE_REGISTRY="${GITEA_IMAGE_REGISTRY:-docker.io}"
 USE_LOCAL_PACKAGES="${USE_LOCAL_PACKAGES:-false}"  # New flag for local packages
-UPGRADE_3_1_X="${UPGRADE_3_1_X:-true}"
+# UPGRADE_FROM_3_1_X indicates SOURCE version: true=upgrading FROM 3.1.3, false=upgrading FROM 2025.02
+UPGRADE_FROM_3_1_X="${UPGRADE_FROM_3_1_X:-true}"  # Default: upgrading from 3.1.3
 
 ### Variables
 cwd=$(pwd)
@@ -624,20 +629,31 @@ cleanup_gitea_secrets() {
 usage() {
     cat >&2 <<EOF
 Purpose:
-Upgrade OnPrem Edge Orchestrator to v3.1.0.
+Upgrade OnPrem Edge Orchestrator to latest version.
+
+Supports two upgrade paths:
+  1. From v3.1.3 to latest (use -u true or omit, this is default)
+  2. From v2025.02 to latest (use -u false)
 
 Usage:
 $(basename "$0") [option...] [argument]
 
-ex:
-./onprem_upgrade.sh -b
-./onprem_upgrade.sh -bl  # Use local packages with backup
+Examples:
+./onprem_upgrade.sh -b              # Upgrade from 3.1.3 with backup (default)
+./onprem_upgrade.sh -bl             # Upgrade from 3.1.3 with local packages and backup
+./onprem_upgrade.sh -u false     # Upgrade from 2025.02 with backup
+./onprem_upgrade.sh -u true         # Explicitly upgrade from 3.1.3
 
 Options:
     -b:             enable backup of Orchestrator PVs before upgrade (optional)
     -l:             use local packages instead of downloading (optional)
     -o:             override production values with dev values (optional)
+    -u [true|false]: specify SOURCE version to upgrade FROM:
+                       true  = upgrading FROM v3.1.3 (default)
+                       false = upgrading FROM v2025.02
     -h:             help (optional)
+
+Note: The -u flag sets UPGRADE_FROM_3_1_X variable.
 
 EOF
 }
@@ -647,21 +663,38 @@ EOF
 ################################
 
 # shellcheck disable=SC2034
-while getopts 'v:hbol' flag; do
+while getopts 'v:hbolu:' flag; do
     case "${flag}" in
     h) HELP='true' ;;
     b) BACKUP='true' ;;
     o) OVERRIDE='true' ;;
     l) USE_LOCAL_PACKAGES='true' ;;  # New local packages flag
+    u) UPGRADE_FROM_3_1_X="${OPTARG}" ;;  # Set UPGRADE_FROM_3_1_X from command-line
     *) HELP='true' ;;
     esac
 done
+
+# Validate UPGRADE_FROM_3_1_X value
+if [[ "$UPGRADE_FROM_3_1_X" != "true" && "$UPGRADE_FROM_3_1_X" != "false" ]]; then
+    echo "Error: UPGRADE_FROM_3_1_X must be 'true' or 'false'. Got: $UPGRADE_FROM_3_1_X"
+    usage
+    exit 1
+fi
+
+# Export for use in upgrade_postgres.sh
+export UPGRADE_FROM_3_1_X
 
 if [[ $HELP ]]; then
     usage
     exit 1
 fi
 
+# Log which upgrade path is being used
+if [[ "$UPGRADE_FROM_3_1_X" == "true" ]]; then
+    log_info "Upgrade path: FROM v3.1.3 TO latest"
+else
+    log_info "Upgrade path: FROM v2025.02 TO latest"
+fi
 
 # Check if postgres is running and if it is safe to backup
 check_postgres
@@ -672,7 +705,7 @@ fi
 
 # Perform PostgreSQL secret backup if not done already
 if [[ ! -f postgres_secret.yaml ]]; then
-    if [[ "$UPGRADE_3_1_X" == "true" ]]; then
+    if [[ "$UPGRADE_FROM_3_1_X" == "true" ]]; then
         kubectl get secret -n orch-database postgresql -o yaml > postgres_secret.yaml
     else
         kubectl get secret -n orch-database passwords -o yaml > postgres_secret.yaml
@@ -810,7 +843,7 @@ if [[ ! -s postgres-secrets-password.txt ]]; then
     IAM_TENANCY=$(kubectl get secret iam-tenancy-local-postgresql -n orch-iam -o jsonpath='{.data.PGPASSWORD}')
     PLATFORM_KEYCLOAK=$(kubectl get secret platform-keycloak-local-postgresql -n orch-platform -o jsonpath='{.data.PGPASSWORD}')
     VAULT=$(kubectl get secret vault-local-postgresql -n orch-platform -o jsonpath='{.data.PGPASSWORD}')
-    if [[ "$UPGRADE_3_1_X" == "true" ]]; then
+    if [[ "$UPGRADE_FROM_3_1_X" == "true" ]]; then
         POSTGRESQL=$(kubectl get secret postgresql -n orch-database -o jsonpath='{.data.postgres-password}')
     else
         POSTGRESQL=$(kubectl get secret orch-database-postgresql -n orch-database -o jsonpath='{.data.password}')
@@ -1066,7 +1099,7 @@ patch_secrets
 sleep 10
 
 # Restore secret after app delete but before postgress restored
-if [[ "$UPGRADE_3_1_X" == "true" ]]; then
+if [[ "$UPGRADE_FROM_3_1_X" == "true" ]]; then
         yq e 'del(.metadata.labels, .metadata.annotations, .metadata.uid, .metadata.creationTimestamp)' postgres_secret.yaml | kubectl apply -f -
 else
         yq e '

--- a/on-prem-installers/onprem/upgrade_postgres.sh
+++ b/on-prem-installers/onprem/upgrade_postgres.sh
@@ -11,7 +11,11 @@ local_backup_path="${POSTGRES_LOCAL_BACKUP_PATH}${local_backup_file}"
 POSTGRES_USERNAME="postgres"
 application_namespace=onprem
 
-if [[ "$UPGRADE_3_1_X" == "true" ]]; then
+# UPGRADE_FROM_3_1_X is set and exported by onprem_upgrade.sh
+# Default to true if not set (upgrading FROM 3.1.3)
+UPGRADE_FROM_3_1_X="${UPGRADE_FROM_3_1_X:-true}"
+
+if [[ "$UPGRADE_FROM_3_1_X" == "true" ]]; then
     podname="postgresql-0"
 else
     podname="postgresql-cluster-1"
@@ -54,7 +58,7 @@ backup_postgres() {
   fi
   echo "Backing up databases from pod $podname in namespace $postgres_namespace..."
 
-  if [[ "$UPGRADE_3_1_X" == "true" ]]; then
+  if [[ "$UPGRADE_FROM_3_1_X" == "true" ]]; then
         remote_backup_path="/tmp/${postgres_namespace}_backup.sql"
   else
         remote_backup_path="/var/lib/postgresql/data/${postgres_namespace}_backup.sql"
@@ -109,7 +113,7 @@ restore_postgres() {
   echo "Restoring backup databases from pod $podname in namespace $postgres_namespace..."
 
   # Get postgres password from secret
-  if [[ "$UPGRADE_3_1_X" == "true" ]]; then
+  if [[ "$UPGRADE_FROM_3_1_X" == "true" ]]; then
         PGPASSWORD=$(kubectl get secret -n $postgres_namespace postgresql -o jsonpath='{.data.postgres-password}' | base64 -d)
 else
         PGPASSWORD=$(kubectl get secret -n $postgres_namespace orch-database-postgresql -o jsonpath='{.data.password}' | base64 -d)


### PR DESCRIPTION
PR address:

1. Update passwords patching
2. Root-App sync stability .
3. To delete Kyverno leftover pods
4. RC1 to RC2 upgrade  fix

https://jira.devtools.intel.com/browse/ITEP-82547 (keycloak login)
https://jira.devtools.intel.com/browse/ITEP-82548 (Infra-external degrade)
https://jira.devtools.intel.com/browse/ITEP-82529 (kyverno image pull issue)


### Description

The upgrade script for onprem currently patches the secret in the wrong namespace. This PR updates the namespace to orch-database. Also this PR removes the second set of commands where the secrets are patched. The chart will automatically update the secrets in the database. 

With the new version of postgres whenever a secret is modified, It is automatically updated in the database. there seems to be some job that runs a update table.

Fixes # (issue)

### Any Newly Introduced Dependencies

n/a

### How Has This Been Tested?

locally

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
