### PR TITLE
Update virtual-integration.yml adding on: pull_request_target

### DIFF
--- a/.github/workflows/virtual-integration.yml
+++ b/.github/workflows/virtual-integration.yml
@@ -13,6 +13,15 @@ on:
       - main
       - main-pass-validation
 
+  # Trigger workflow on PRs from forked repos for all branches
+  pull_request_target:
+    branches:
+      - "*"
+    types:
+      - opened
+      - synchronize
+      - reopened
+
   # Trigger workflow on PRs to all branches
   pull_request:
     branches:


### PR DESCRIPTION
### Description

External contributor's PR cannot access secrets as

1. pull_request runs in the PR (fork) code context, but inside the target repository:
When a PR is opened from a fork, an upstream workflow with on: pull_request runs in the target repository using a read‑only GITHUB_TOKEN and without secrets. This is by design to protect secrets from untrusted code. [stackoverflow.com], [runs-on.com]


2. pull_request_target runs in the base repository context and has secrets:
on: pull_request_target executes against the base repository’s default branch, with access to secrets and a write token, but you must not check out or execute untrusted PR code. (GitHub tightened this on Dec 8, 2025 so that the workflow source is always the default branch.)

Fixes # 
https://jira.devtools.intel.com/browse/ITEP-82240

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
