### PR TITLE
Remove cleanupJobs configuration and bump kyverno chart to 3.6.1

### DIFF
--- a/argocd/applications/configs/kyverno.yaml
+++ b/argocd/applications/configs/kyverno.yaml
@@ -2,65 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-webhooksCleanup:
-  image:
-    registry: docker.io
-    repository: eclipsefdn/kubectl
-    tag: okd-c1
-  securityContext:
-    runAsNonRoot: true
-    runAsUser: 1001
-policyReportCleanup:
-  image:
-    registry: docker.io
-    repository: eclipsefdn/kubectl
-    tag: okd-c1
-  securityContext:
-    runAsNonRoot: true
-    runAsUser: 1001
-
-cleanupJobs:
-  admissionReports:
-    image:
-      registry: docker.io
-      repository: eclipsefdn/kubectl
-      tag: okd-c1
-    securityContext:
-      runAsNonRoot: true
-      runAsUser: 1001
-  clusterAdmissionReports:
-    image:
-      registry: docker.io
-      repository: eclipsefdn/kubectl
-      tag: okd-c1
-    securityContext:
-      runAsNonRoot: true
-      runAsUser: 1001
-  clusterEphemeralReports:
-    image:
-      registry: docker.io
-      repository: eclipsefdn/kubectl
-      tag: okd-c1
-    securityContext:
-      runAsNonRoot: true
-      runAsUser: 1001
-  ephemeralReports:
-    image:
-      registry: docker.io
-      repository: eclipsefdn/kubectl
-      tag: okd-c1
-    securityContext:
-      runAsNonRoot: true
-      runAsUser: 1001
-  updateRequests:
-    image:
-      registry: docker.io
-      repository: eclipsefdn/kubectl
-      tag: okd-c1
-    securityContext:
-      runAsNonRoot: true
-      runAsUser: 1001
-
 # Deploy minimally viable HA config. See https://kyverno.io/docs/installation/methods/#high-availability
 # Migrate to v1.13 https://kyverno.io/docs/installation/upgrading/#upgrading-to-kyverno-v113
 admissionController:

--- a/argocd/applications/templates/kyverno.yaml
+++ b/argocd/applications/templates/kyverno.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: https://kyverno.github.io/kyverno
       chart: kyverno
-      targetRevision: 3.5.1
+      targetRevision: 3.6.1
       helm:
         releaseName: {{$appName}}
         valuesObject:


### PR DESCRIPTION
### Description

This PR removes cleanupJobs configuration from the kyverno chart and bumps the chart version to 3.6.1.

Fixes # (issue)

### Any Newly Introduced Dependencies

n/a

### How Has This Been Tested?

ci
### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
