### PR TITLE
fix: botkube helm chart updated

### DIFF
--- a/argocd/applications/templates/botkube.yaml
+++ b/argocd/applications/templates/botkube.yaml
@@ -19,9 +19,9 @@ metadata:
 spec:
   project: {{ required "A valid projectName entry required!" .Values.argo.project }}
   sources:
-    - repoURL: "https://charts.botkube.io/"
-      chart: botkube
-      targetRevision: 1.11.0
+    - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
+      chart: common/charts/botkube
+      targetRevision: v1.11.0
       helm:
         releaseName: {{$appName}}
         valuesObject:


### PR DESCRIPTION
### Description

- botkube argocd application template was updated to point to the Intel release service instead of charts.botkube.io because botkube.io is down. 
- v1.11.0 chart was packaged from botkube github source and uploaded to the release service

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
