### PR TITLE
Update virtual-integration.yml to skip build & test for dependabot PR's

### DIFF
--- a/.github/workflows/virtual-integration.yml
+++ b/.github/workflows/virtual-integration.yml
@@ -338,7 +338,8 @@ jobs:
       needs.check-changed-files.outputs.ci == 'true' ||
       needs.check-changed-files.outputs.test-automation == 'true' ||
       github.ref == 'refs/heads/main' ||
-      github.ref == 'refs/heads/main-pass-validation'
+      github.ref == 'refs/heads/main-pass-validation' ||
+      github.actor != 'dependabot[bot]'
       )
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -475,7 +476,8 @@ jobs:
       needs.check-changed-files.outputs.orch == 'true' ||
       needs.check-changed-files.outputs.ci == 'true' ||
       github.ref == 'refs/heads/main' ||
-      github.ref == 'refs/heads/main-pass-validation'
+      github.ref == 'refs/heads/main-pass-validation' !!
+      github.actor != 'dependabot[bot]'
       )
     runs-on: ubuntu-24.04-16core-64GB
     timeout-minutes: 90


### PR DESCRIPTION
Update virtual-integration.yml to skip build & test for dependabot PR's

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
