### PR TITLE
Update virtual-integration.yml to use the latest ORCH-CI version 2026.0.8

### DIFF
--- a/.github/workflows/virtual-integration.yml
+++ b/.github/workflows/virtual-integration.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Discover Changed Files
         id: check-files
-        uses: open-edge-platform/orch-ci/discover-changed-files@main  # zizmor: ignore[unpinned-uses]
+        uses: open-edge-platform/orch-ci/discover-changed-files@467367d6f859a4654f2645ca78efd60035cf390c  # 2026.0.8 # zizmor: ignore[unpinned-uses]
         with:
           project_folder: "."
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to use a newer version of the shared CI workflow. This ensures the project benefits from the latest improvements and fixes in the CI process.

CI workflow update:

* [`.github/workflows/virtual-integration.yml`](diffhunk://#diff-c115eba42a2e0ffbf4166b2a198deed597826f1299a9593c50b1bc1edd6e71c6L42-R42): Updated the reference for the `pre-merge.yml` workflow from version `0.1.66` to `2026.0.8` to use the latest CI workflow features and fixes.