### PR TITLE
Update postgresql-secrets chart version

### DIFF
--- a/argocd/applications/templates/postgresql-secrets.yaml
+++ b/argocd/applications/templates/postgresql-secrets.yaml
@@ -19,7 +19,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: common/charts/{{$appName}}
-      targetRevision: 25.2.4
+      targetRevision: 26.0.1
       helm:
         releaseName: {{$appName}}
         valuesObject:


### PR DESCRIPTION
### Description

This PR updates the postgresql-secrets chart version to remove a leftover secret.

The secret that is being removed was used for bitnami postgresql chart and it is not required anymore.

https://github.com/open-edge-platform/orch-utils/commit/d24ce0945e223e1bfa7928e87ddbe6d1a892261a
Fixes # (issue)

### Any Newly Introduced Dependencies

n/a

### How Has This Been Tested?

ci
### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
