### PR TITLE
Execute onprem OXM VIP job only if the changes are in EIM infra-

### DIFF
--- a/.github/workflows/virtual-integration.yml
+++ b/.github/workflows/virtual-integration.yml
@@ -59,6 +59,10 @@ jobs:
       markdown: ${{ contains(steps.check-files.outputs.changed_files, '.md') || contains(steps.check-files.outputs.changed_files, '.markdown') || contains(steps.check-files.outputs.changed_files, '.mdx') }}
       orch: ${{ contains(steps.check-files.outputs.changed_files, 'argocd') || contains(steps.check-files.outputs.changed_files, 'bootstrap') || contains(steps.check-files.outputs.changed_files, 'installer') || contains(steps.check-files.outputs.changed_files, 'internal') || contains(steps.check-files.outputs.changed_files, 'mage') || contains(steps.check-files.outputs.changed_files, 'node') || contains(steps.check-files.outputs.changed_files, 'router') || contains(steps.check-files.outputs.changed_files, 'tools') || contains(steps.check-files.outputs.changed_files, 'e2e-tests') || contains(steps.check-files.outputs.changed_files, 'VERSION') || contains(steps.check-files.outputs.changed_files, 'orch-configs') }}
       on-prem: ${{ contains(steps.check-files.outputs.changed_files, 'on-prem-installers') || contains(steps.check-files.outputs.changed_files, 'terraform') }}
+      on-prem-oxm: ${{ contains(steps.check-files.outputs.changed_files, 'argocd/applications/configs/infra-') ||
+        contains(steps.check-files.outputs.changed_files, 'argocd/applications/custom/infra-') ||
+        contains(steps.check-files.outputs.changed_files, 'argocd/applications/templates/infra-') ||
+        contains(steps.check-files.outputs.changed_files, 'argocd/applications/values.yaml') }}
       onboarding: ${{ contains(steps.check-files.outputs.changed_files, 'argocd/applications/templates/infra-') || contains(steps.check-files.outputs.changed_files, 'argocd/applications/values.yaml') }}
       shell: ${{ contains(steps.check-files.outputs.changed_files, '.sh') || contains(steps.check-files.outputs.changed_files, '.bash') }}
       terraform: ${{ contains(steps.check-files.outputs.changed_files, '.hcl') || contains(steps.check-files.outputs.changed_files, '.tf') || contains(steps.check-files.outputs.changed_files, '.tfvars') }}
@@ -785,13 +789,7 @@ jobs:
     if: |
       always() &&
       needs.build-publish.result == 'success' &&
-      needs.check-changed-files.outputs.only_design_proposals != 'true' && (
-      needs.check-changed-files.outputs.orch == 'true' ||
-      needs.check-changed-files.outputs.on-prem == 'true' ||
-      needs.check-changed-files.outputs.ci == 'true' ||
-      github.ref == 'refs/heads/main' ||
-      github.ref == 'refs/heads/main-pass-validation'
-      )
+      needs.check-changed-files.outputs.on-prem-oxm == 'true'
     runs-on: ubuntu-22.04-16core-64GB
     timeout-minutes: 90
     env:


### PR DESCRIPTION
### Description

This pull request updates the `.github/workflows/virtual-integration.yml` workflow to introduce and utilize a new conditional flag for on-premises infrastructure changes. The changes add more granular control over when certain jobs run in response to specific file changes related to infrastructure configuration.

Key changes:

**Workflow condition enhancements:**

* Added a new `on-prem-oxm` condition to detect changes in `argocd/applications/configs/infra-`, `argocd/applications/custom/infra-`, `argocd/applications/templates/infra-`, and `argocd/applications/values.yaml` files. This allows for more targeted triggering of jobs when infrastructure-related files are modified.

**Job execution logic:**

* Modified the job execution condition to trigger only when the new `on-prem-oxm` flag is set to `true`, rather than a broader set of flags. This narrows the scope of the job to changes specifically affecting on-premises infrastructure configuration.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code