### PR TITLE
Update auto-update.yml to the latest Orch-CI version

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -34,7 +34,7 @@ jobs:
           persist-credentials: false
 
       - name: Update pull requests
-        uses: open-edge-platform/orch-ci/.github/actions/pr_updater@592eafb7c84669729eb1adc610515bad61c3550b  # 0.1.67
+        uses: open-edge-platform/orch-ci/.github/actions/pr_updater@467367d6f859a4654f2645ca78efd60035cf390c  # 2026.0.8
         with:
           github_token: ${{ secrets.SYS_EMF_GH_TOKEN }}
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to use a newer version of the `pr_updater` action. This ensures that the workflow benefits from the latest features, improvements, and bug fixes provided in the updated action.

Workflow update:

* Updated the `pr_updater` action in `.github/workflows/auto-update.yml` from version `0.1.67` to `2026.0.8`.