### PR TITLE
Bump cert-synchronizer and keycloak-tenant-controller charts to 26.0.3

### DIFF
--- a/argocd/applications/templates/cert-synchronizer.yaml
+++ b/argocd/applications/templates/cert-synchronizer.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Intel Corporation
+# SPDX-FileCopyrightText: 2026 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/argocd/applications/templates/keycloak-tenant-controller.yaml
+++ b/argocd/applications/templates/keycloak-tenant-controller.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Intel Corporation
+# SPDX-FileCopyrightText: 2026 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
### Description

This PR bumps cert-synchronizer and keycloak-tenant-controller charts to 26.0.3 to bring the following changes:
https://github.com/open-edge-platform/orch-utils/pull/461
https://github.com/open-edge-platform/orch-utils/pull/460


Fixes # (issue)

### Any Newly Introduced Dependencies

n/a

### How Has This Been Tested?

ci

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
