### PR TITLE
Fix bug in rke2 upgrade utility

### DIFF
--- a/on-prem-installers/mage/upgrade.go
+++ b/on-prem-installers/mage/upgrade.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Intel Corporation
+// SPDX-FileCopyrightText: 2026 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -295,6 +295,7 @@ func determineUpgradePath(currentVersion, targetVersion string) []string {
 		"v1.31.13+rke2r1", // Upgrade to 1.31
 		"v1.32.9+rke2r1",  // Upgrade to 1.32
 		"v1.33.5+rke2r1",  // Upgrade to 1.33
+		"v1.34.1+rke2r1",  // Upgrade to 1.34
 		"v1.34.3+rke2r1",  // Final target version
 	}
 
@@ -313,9 +314,12 @@ func determineUpgradePath(currentVersion, targetVersion string) []string {
 	// Find starting index
 	startIdx := -1
 	for i, v := range allVersions {
-		if strings.Contains(v, currentMinor) {
+		if v == currentVersion {
 			startIdx = i
 			break
+		}
+		if strings.Contains(v, currentMinor) && startIdx == -1 {
+			startIdx = i
 		}
 	}
 
@@ -329,9 +333,12 @@ func determineUpgradePath(currentVersion, targetVersion string) []string {
 	// Find ending index
 	endIdx := -1
 	for i, v := range allVersions {
-		if strings.Contains(v, targetMinor) {
+		if v == targetVersion {
 			endIdx = i
 			break
+		}
+		if strings.Contains(v, targetMinor) {
+			endIdx = i
 		}
 	}
 


### PR DESCRIPTION
### Description

When running the determineUpgradePath function to identify the upgrade path for rke2, currently the function ignores any patch updates to the latest minor release.

Fixes # (issue)

### Any Newly Introduced Dependencies

n/a

### How Has This Been Tested?

locally

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
