### PR TITLE
ITEP-86011: Added export for BUCKET_REGION for orchestrator installer initialization

### DIFF
--- a/e2e-tests/installer/auto_install.py
+++ b/e2e-tests/installer/auto_install.py
@@ -207,6 +207,11 @@ class AutoInstall:
         self.aws_region = os.getenv("AWS_REGION")
         if self.aws_region is None or len(self.aws_region) == 0:
             raise ValueError("AWS_REGION environment variable is required.")
+        
+        # Set bucket_region variable if it is set, else set it to the AWS_REGION
+        self.bucket_region = os.getenv("BUCKET_REGION")
+        if self.aws_region is None or len(self.aws_region) == 0:
+            self.bucket_region = self.aws_region
 
         self.aws_account = os.getenv("AWS_ACCOUNT")
         if self.aws_account is None or len(self.aws_account) == 0:
@@ -481,6 +486,9 @@ class AutoInstall:
         # image from the release service. The image pull can take 10 minutes or more depending
         # on network performance. Add a specific pull timeout/progress watch phase to verify pull
         # progress when it is being done here.
+
+        # Set the bucket region during init
+        self.installer_session.sendline(f"export BUCKET_REGION={self.bucket_region}")
 
     def start_time_cryer(self):
         """


### PR DESCRIPTION
### Description

Adds an export for BUCKET_REGION to auto_install.py after start-installer script is initialized. Defaults to AWS_REGION if BUCKET_REGION is not specified

Fixes # (issue)

Fixes issue introduced when bucket region was changed from being hardcoded. 

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
