### PR TITLE
S3 public access blocks on buckets and ec2log

### DIFF
--- a/pod-configs/buckets/main.tf
+++ b/pod-configs/buckets/main.tf
@@ -5,3 +5,12 @@
 resource "aws_s3_bucket" "lp_devops_terraform" {
   bucket = var.bucket
 }
+
+# Block all public access (AWS-0086, AWS-0087, AWS-0091, AWS-0093)
+resource "aws_s3_bucket_public_access_block" "lp_devops_terraform" {
+  bucket                  = aws_s3_bucket.lp_devops_terraform.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/pod-configs/module/ec2log/save-log.tf
+++ b/pod-configs/module/ec2log/save-log.tf
@@ -113,6 +113,15 @@ resource "aws_s3_bucket" "logs" {
   }
 }
 
+# Block all public access (AWS-0086, AWS-0087, AWS-0091, AWS-0093)
+resource "aws_s3_bucket_public_access_block" "logs" {
+  bucket                  = aws_s3_bucket.logs.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
 resource "aws_iam_policy" "cloudwatch" {
   name        = "orch-ec2log-${var.cluster_name}-asg-lifecycle"
   path        = "/"

--- a/pod-configs/module/s3/main.tf
+++ b/pod-configs/module/s3/main.tf
@@ -235,3 +235,22 @@ resource "aws_s3_bucket_policy" "tracing_policy" {
   bucket = aws_s3_bucket.tracing[0].id
   policy = data.aws_iam_policy_document.tracing_policy_doc[0].json
 }
+
+# Block all public access (AWS-0086, AWS-0087, AWS-0091, AWS-0093)
+resource "aws_s3_bucket_public_access_block" "bucket" {
+  for_each                = local.buckets
+  bucket                  = aws_s3_bucket.bucket[each.key].id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_public_access_block" "tracing" {
+  count                   = var.create_tracing ? 1 : 0
+  bucket                  = aws_s3_bucket.tracing[0].id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}


### PR DESCRIPTION
Add aws_s3_bucket_public_access_block to restrict public access on s3 buckets.

Fixes AWS-0086 AWS-0087 AWS-0091 AWS-0093


### Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
