### PR TITLE
CI updates for release-2026.0 branch

### DIFF
--- a/.github/workflows/auto-approve-merge.yml
+++ b/.github/workflows/auto-approve-merge.yml
@@ -23,7 +23,7 @@ jobs:
           REPO: ${{ github.repository }}
           ACTOR: ${{ github.actor }}
         if: github.actor == github.actor == 'sys-orch' && 
-          github.event.pull_request.base.ref == 'main-pass-validation'
+          github.event.pull_request.base.ref == '2026.0-pass-validation'
         run: |
           echo "Approving PR #${PR_NUMBER} by ${ACTOR}"
           gh pr review "${PR_NUMBER}" --repo "${REPO}" --approve --body "Auto approved by sys-orch-github-approve bot"
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.actor == 'sys-orch' && 
-      github.event.pull_request.base.ref == 'main-pass-validation'
+      github.event.pull_request.base.ref == '2026.0-pass-validation'
     steps:
       - name: Auto merge
         env:

--- a/.github/workflows/test-migration.yml
+++ b/.github/workflows/test-migration.yml
@@ -11,8 +11,7 @@ on:
   # Run on all commits that are pushed to all branches
   push:
     branches:
-      - main
-      - main-pass-validation
+      - release-2026.0
 
   # Trigger workflow on PRs to all branches
   pull_request:

--- a/.github/workflows/virtual-integration.yml
+++ b/.github/workflows/virtual-integration.yml
@@ -10,8 +10,7 @@ on:
   # Run on all commits that are pushed to all branches
   push:
     branches:
-      - main
-      - main-pass-validation
+      - release-2026.0
 
   # Trigger workflow on PRs to all branches
   pull_request:
@@ -131,7 +130,7 @@ jobs:
     name: Lint Markdown
     needs:
       - check-changed-files
-    if: needs.check-changed-files.outputs.markdown == 'true' ||  github.ref == 'refs/heads/main' || github.ref == 'refs/heads/main-pass-validation'
+    if: needs.check-changed-files.outputs.markdown == 'true' ||  github.ref == 'refs/heads/release-2026.0'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -168,7 +167,7 @@ jobs:
     name: Lint shell scripts
     needs:
       - check-changed-files
-    if: needs.check-changed-files.outputs.shell == 'true' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/main-pass-validation'
+    if: needs.check-changed-files.outputs.shell == 'true' || github.ref == 'refs/heads/release-2026.0'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -190,7 +189,7 @@ jobs:
     name: Lint Terraform
     needs:
       - check-changed-files
-    if: needs.check-changed-files.outputs.terraform == 'true' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/main-pass-validation'
+    if: needs.check-changed-files.outputs.terraform == 'true' || github.ref == 'refs/heads/release-2026.0'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -211,7 +210,7 @@ jobs:
     name: Lint YAML
     needs:
       - check-changed-files
-    if: needs.check-changed-files.outputs.yaml == 'true' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/main-pass-validation'
+    if: needs.check-changed-files.outputs.yaml == 'true' || github.ref == 'refs/heads/release-2026.0'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -234,7 +233,7 @@ jobs:
     name: Lint Helm
     needs:
       - check-changed-files
-    if: needs.check-changed-files.outputs.helm == 'true' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/main-pass-validation'
+    if: needs.check-changed-files.outputs.helm == 'true' || github.ref == 'refs/heads/release-2026.0'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -255,7 +254,7 @@ jobs:
     name: Lint Go
     needs:
       - check-changed-files
-    if: needs.check-changed-files.outputs.go == 'true' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/main-pass-validation'
+    if: needs.check-changed-files.outputs.go == 'true' || github.ref == 'refs/heads/release-2026.0'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -332,8 +331,7 @@ jobs:
       needs.check-changed-files.outputs.on-prem == 'true' ||
       needs.check-changed-files.outputs.ci == 'true' ||
       needs.check-changed-files.outputs.test-automation == 'true' ||
-      github.ref == 'refs/heads/main' ||
-      github.ref == 'refs/heads/main-pass-validation'
+      github.ref == 'refs/heads/release-2026.0'
       )
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -438,18 +436,18 @@ jobs:
           path: trivy-orchestrator-installer-cloudfull.txt
 
       - name: Publish Cloud Installer artifact
-        if: github.event_name == 'push' && ( github.ref == 'refs/heads/main' || github.ref == 'refs/heads/main-pass-validation' )
+        if: github.event_name == 'push' && ( github.ref == 'refs/heads/release-2026.0' )
         run: mage publish:cloudInstaller
 
       - name: Build release manifest artifact
-        if: github.event_name == 'push' && ( github.ref == 'refs/heads/main' || github.ref == 'refs/heads/main-pass-validation' )
+        if: github.event_name == 'push' && ( github.ref == 'refs/heads/release-2026.0' )
         run: |
           mkdir -p release-manifest
           mage -v gen:releaseManifest release-manifest/chart-manifest.yaml
           mage -v gen:releaseImageManifest release-manifest/image-manifest.yaml
 
       - name: Publish release manifest artifact
-        if: github.event_name == 'push' && ( github.ref == 'refs/heads/main' || github.ref == 'refs/heads/main-pass-validation' )
+        if: github.event_name == 'push' && ( github.ref == 'refs/heads/release-2026.0' )
         run: |
           mage publish:releaseManifest
 
@@ -472,8 +470,7 @@ jobs:
       needs.check-changed-files.outputs.only_design_proposals != 'true' && (
       needs.check-changed-files.outputs.orch == 'true' ||
       needs.check-changed-files.outputs.ci == 'true' ||
-      github.ref == 'refs/heads/main' ||
-      github.ref == 'refs/heads/main-pass-validation'
+      github.ref == 'refs/heads/release-2026.0'
       )
     runs-on: ubuntu-24.04-16core-64GB
     timeout-minutes: 90
@@ -668,8 +665,7 @@ jobs:
       needs.check-changed-files.outputs.on-prem == 'true' ||
       needs.check-changed-files.outputs.ci == 'true' ||
       needs.check-changed-files.outputs.test-automation == 'true' ||
-      github.ref == 'refs/heads/main' ||
-      github.ref == 'refs/heads/main-pass-validation'
+      github.ref == 'refs/heads/release-2026.0'
       )
     runs-on: ubuntu-24.04-16core-64GB
     timeout-minutes: 90
@@ -869,7 +865,7 @@ jobs:
       - deploy-kind
       - deploy-on-prem
       - deploy-oxm-profile
-    if: github.event_name == 'push' && ( github.ref == 'refs/heads/main' || github.ref == 'refs/heads/main-pass-validation' )
+    if: github.event_name == 'push' && ( github.ref == 'refs/heads/release-2026.0' )
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -899,7 +895,7 @@ jobs:
       security-events: write
       id-token: write
       actions: read
-    if: github.event_name == 'push' && ( github.ref == 'refs/heads/main' || github.ref == 'refs/heads/main-pass-validation' )
+    if: github.event_name == 'push' && ( github.ref == 'refs/heads/release-2026.0' )
     uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@b5930c48c1fcdb6b34ffbcd465cff96dabfbde70  # 2026.0.17
     with:
       run_build: false

--- a/on-prem-installers/onprem/onprem.env
+++ b/on-prem-installers/onprem/onprem.env
@@ -21,7 +21,7 @@ export DEPLOY_VERSION=v2026.0.0
 export ORCH_INSTALLER_PROFILE=onprem
 
 # Git Repositories Configuration
-export DEPLOY_REPO_BRANCH="main"
+export DEPLOY_REPO_BRANCH="release-2026.0"
 
 # =============================================================================
 # AUTHENTICATION & SECURITY


### PR DESCRIPTION
### Description

This pull request updates the CI/CD workflows and environment configuration to transition from the `main` and `main-pass-validation` branches to the new `release-2026.0` branch. The changes ensure that all automated processes, including approvals, merges, linting, artifact publishing, and deployment, now target the new release branch, aligning the workflows with the updated release strategy.

Branch migration in workflows:

* Updated the `auto-approve-merge.yml` workflow to use `2026.0-pass-validation` instead of `main-pass-validation`, ensuring PR approvals and merges are now associated with the new validation branch. [[1]](diffhunk://#diff-7562ba9ef55de195b8d5cfe9c14fa736911de77611b691df1b022e6384eccebaL26-R26) [[2]](diffhunk://#diff-7562ba9ef55de195b8d5cfe9c14fa736911de77611b691df1b022e6384eccebaL42-R42)
* Modified the `test-migration.yml` and `virtual-integration.yml` workflows to trigger on pushes and pull requests to `release-2026.0` instead of `main` and `main-pass-validation`, centralizing CI/CD around the new release branch. [[1]](diffhunk://#diff-e3c347f56a5c1a1c86fdaa601ca1e978324781497ceaacff3e13afa5cb0a5ac4L14-R14) [[2]](diffhunk://#diff-c115eba42a2e0ffbf4166b2a198deed597826f1299a9593c50b1bc1edd6e71c6L13-R13)

Linting and build jobs targeting new branch:

* Changed conditional logic in multiple linting jobs (`Lint Markdown`, `Lint shell scripts`, `Lint Terraform`, `Lint YAML`, `Lint Helm`, `Lint Go`) within `virtual-integration.yml` to run only for `release-2026.0`, removing references to `main` and `main-pass-validation`. [[1]](diffhunk://#diff-c115eba42a2e0ffbf4166b2a198deed597826f1299a9593c50b1bc1edd6e71c6L134-R133) [[2]](diffhunk://#diff-c115eba42a2e0ffbf4166b2a198deed597826f1299a9593c50b1bc1edd6e71c6L171-R170) [[3]](diffhunk://#diff-c115eba42a2e0ffbf4166b2a198deed597826f1299a9593c50b1bc1edd6e71c6L193-R192) [[4]](diffhunk://#diff-c115eba42a2e0ffbf4166b2a198deed597826f1299a9593c50b1bc1edd6e71c6L214-R213) [[5]](diffhunk://#diff-c115eba42a2e0ffbf4166b2a198deed597826f1299a9593c50b1bc1edd6e71c6L237-R236) [[6]](diffhunk://#diff-c115eba42a2e0ffbf4166b2a198deed597826f1299a9593c50b1bc1edd6e71c6L258-R257)

Artifact publishing and deployment updates:

* Updated artifact publishing and deployment steps in `virtual-integration.yml` to trigger only for pushes to `release-2026.0`, ensuring release artifacts and post-merge actions are tied to the new branch. [[1]](diffhunk://#diff-c115eba42a2e0ffbf4166b2a198deed597826f1299a9593c50b1bc1edd6e71c6L441-R450) [[2]](diffhunk://#diff-c115eba42a2e0ffbf4166b2a198deed597826f1299a9593c50b1bc1edd6e71c6L872-R868) [[3]](diffhunk://#diff-c115eba42a2e0ffbf4166b2a198deed597826f1299a9593c50b1bc1edd6e71c6L902-R898)

Environment configuration change:

* Changed the `DEPLOY_REPO_BRANCH` in `onprem.env` from `main` to `release-2026.0`, aligning on-prem installer deployments with the new branch.

Workflow triggers for build and test jobs:

* Updated conditional triggers for build and test jobs throughout `virtual-integration.yml` to reference `release-2026.0`, ensuring all CI/CD jobs are executed for the correct branch. [[1]](diffhunk://#diff-c115eba42a2e0ffbf4166b2a198deed597826f1299a9593c50b1bc1edd6e71c6L335-R334) [[2]](diffhunk://#diff-c115eba42a2e0ffbf4166b2a198deed597826f1299a9593c50b1bc1edd6e71c6L475-R473) [[3]](diffhunk://#diff-c115eba42a2e0ffbf4166b2a198deed597826f1299a9593c50b1bc1edd6e71c6L671-R668)

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
