### PR TITLE
Fix wrong resource name in secrets-config chart

### DIFF
--- a/argocd/applications/templates/secrets-config.yaml
+++ b/argocd/applications/templates/secrets-config.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: common/charts/{{$appName}}
-      targetRevision: 3.0.6
+      targetRevision: 26.0.2
       helm:
         releaseName: {{$appName}}
         valuesObject:


### PR DESCRIPTION
### Description

Currently the secrets-config name uses an old outdated version.

This update to the secrets-config brings in a change in the wrong resource name when applying the RoleBinding resource https://github.com/open-edge-platform/orch-utils/pull/644 

Fixes # (issue)

### Any Newly Introduced Dependencies

n/a

### How Has This Been Tested?

ci

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
