### PR TITLE
Bump cloudnative-pg cluster chart to 0.6.0

### DIFF
--- a/argocd/applications/templates/postgresql-cluster.yaml
+++ b/argocd/applications/templates/postgresql-cluster.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Intel Corporation
+# SPDX-FileCopyrightText: 2026 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
### Description

Bump cloudnative-pg cluster chart to 0.6.0

Fixes # (issue)

### Any Newly Introduced Dependencies

n/a

### How Has This Been Tested?

ci

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
