### PR TITLE
Bump version for orch-utils charts to bring in golang-1.26.1 and tenancy-api-mapping changes

### DIFF
--- a/argocd/applications/templates/auth-service.yaml
+++ b/argocd/applications/templates/auth-service.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: common/charts/{{$appName}}
-      targetRevision: 26.0.9
+      targetRevision: 26.1.0
       helm:
         releaseName: {{$appName}}
         valuesObject:

--- a/argocd/applications/templates/aws-sm-proxy.yaml
+++ b/argocd/applications/templates/aws-sm-proxy.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid rsChartRepoURL entry required!" .Values.argo.rsChartRepoURL }}
       chart: common/charts/{{$appName}}
-      targetRevision: 26.0.9
+      targetRevision: 26.1.0
       helm:
         releaseName: {{$appName}}
         valuesObject:

--- a/argocd/applications/templates/cert-synchronizer.yaml
+++ b/argocd/applications/templates/cert-synchronizer.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: common/charts/cert-synchronizer
-      targetRevision: 26.0.13
+      targetRevision: 26.1.0
       helm:
         releaseName: {{$appName}}
         valuesObject:

--- a/argocd/applications/templates/component-status.yaml
+++ b/argocd/applications/templates/component-status.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Intel Corporation
+# SPDX-FileCopyrightText: 2026 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: common/charts/{{$appName}}
-      targetRevision: 26.0.4
+      targetRevision: 26.1.0
       helm:
         releaseName: {{$appName}}
         valuesObject:

--- a/argocd/applications/templates/keycloak-tenant-controller.yaml
+++ b/argocd/applications/templates/keycloak-tenant-controller.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: common/charts/keycloak-tenant-controller
-      targetRevision: 26.0.21
+      targetRevision: 26.1.0
       helm:
         releaseName: {{$appName}}
         valuesObject:

--- a/argocd/applications/templates/nexus-api-gw.yaml
+++ b/argocd/applications/templates/nexus-api-gw.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: common/charts/nexus-api-gw
-      targetRevision: 26.0.9
+      targetRevision: 26.1.0
       helm:
         releaseName: {{$appName}}
         valuesObject:

--- a/argocd/applications/templates/tenancy-api-mapping.yaml
+++ b/argocd/applications/templates/tenancy-api-mapping.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: common/charts/{{$appName}}
-      targetRevision: 26.0.14
+      targetRevision: 26.0.15
       helm:
         releaseName: {{$appName}}
         valuesObject:

--- a/argocd/applications/templates/tenancy-datamodel.yaml
+++ b/argocd/applications/templates/tenancy-datamodel.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: common/charts/{{$appName}}
-      targetRevision: 26.0.4
+      targetRevision: 26.1.0
       helm:
         releaseName: {{$appName}}
         valuesObject:

--- a/argocd/applications/templates/tenancy-init.yaml
+++ b/argocd/applications/templates/tenancy-init.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: common/charts/{{$appName}}
-      targetRevision: 26.0.5
+      targetRevision: 26.1.0
       helm:
         releaseName: {{$appName}}
         valuesObject:

--- a/argocd/applications/templates/tenancy-manager.yaml
+++ b/argocd/applications/templates/tenancy-manager.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: common/charts/tenancy-manager
-      targetRevision: 26.0.4
+      targetRevision: 26.1.0
       helm:
         releaseName: {{$appName}}
         valuesObject:

--- a/argocd/applications/templates/token-fs.yaml
+++ b/argocd/applications/templates/token-fs.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Intel Corporation
+# SPDX-FileCopyrightText: 2026 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: common/charts/{{$appName}}
-      targetRevision: 26.0.2
+      targetRevision: 26.1.0
       helm:
         releaseName: {{$appName}}
         valuesObject:


### PR DESCRIPTION
### Description

Bump orch-utils chart version to bring in:

golang-1.26.1 changes https://github.com/open-edge-platform/orch-utils/pull/669

and tenancy-api-mapping updates:

https://github.com/open-edge-platform/orch-utils/pull/668
https://github.com/open-edge-platform/orch-utils/pull/667
https://github.com/open-edge-platform/orch-utils/pull/666


Fixes # (issue)

### Any Newly Introduced Dependencies

n/a

### How Has This Been Tested?

ci
### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
