### PR TITLE
Bump traefik chart to v39.0.6

### DIFF
--- a/argocd/applications/custom/traefik.tpl
+++ b/argocd/applications/custom/traefik.tpl
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Intel Corporation
+# SPDX-FileCopyrightText: 2026 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -34,17 +34,23 @@ ports:
       default: false
   websecure:
     nodePort: 30443
-    # NOTE the middlewared name is <namespace>-<name>
-    middlewares:
-      - orch-gateway-rate-limit@kubernetescrd
-      {{- if index .Values "argo" "cors"}}
-      {{- if index .Values "argo" "cors" "enabled" }}
-      - orch-gateway-cors@kubernetescrd
-      {{- end }}
-      {{- end }}
+    # Breaking change when migrating to v39.0.0. See:
+    # https://github.com/traefik/traefik-helm-chart/releases/tag/v39.0.0
+    http:
+        # NOTE the middlewared name is <namespace>-<name>    
+        middlewares:
+        - orch-gateway-rate-limit@kubernetescrd
+        {{- if index .Values "argo" "cors"}}
+        {{- if index .Values "argo" "cors" "enabled" }}
+        - orch-gateway-cors@kubernetescrd
+        {{- end }}
+        {{- end }}
   tcpamt:
-    middlewares:
-      - orch-gateway-tcp-rate-limit@kubernetescrd
+    # Breaking change when migrating to v39.0.0. See:
+    # https://github.com/traefik/traefik-helm-chart/releases/tag/v39.0.0
+    http:
+        middlewares:
+        - orch-gateway-tcp-rate-limit@kubernetescrd
     port: 4433
     exposedPort: 4433
     expose:

--- a/argocd/applications/templates/traefik.yaml
+++ b/argocd/applications/templates/traefik.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Intel Corporation
+# SPDX-FileCopyrightText: 2026 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: https://helm.traefik.io/traefik
       chart: traefik
-      targetRevision: 37.2.0
+      targetRevision: 39.0.6
       helm:
         releaseName: {{$appName}}
         valuesObject:


### PR DESCRIPTION
### Description

Bump traefik chart to v39.0.6

This includes a breaking change as part of migration to v39.0.0 documented here https://github.com/traefik/traefik-helm-chart/releases/tag/v39.0.0 

Proposed solution/workaround discussed here https://github.com/traefik/traefik-helm-chart/pull/1603 

Fixes # (issue)

### Any Newly Introduced Dependencies

n/a

### How Has This Been Tested?

ci
### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
