### PR TITLE
WIP single IP k3s deployments - DO NOT MERGE

### DIFF
--- a/SINGLE-IP-POC.md
+++ b/SINGLE-IP-POC.md
@@ -1,0 +1,295 @@
+# Single-IP K3s Orchestrator POC
+
+## Summary
+
+This document records the work done on 2026-03-31 to deploy Edge Orchestrator on a
+single Coder VM using K3s with a single IP address for all MetalLB LoadBalancer services.
+
+In a standard on-prem deployment, three separate IPs are required for ArgoCD, Traefik,
+and HAProxy. This is impractical for Coder VMs and other environments with limited IP
+addresses. Single-IP mode puts all three services on one IP using different ports:
+
+| Service  | Port |
+|----------|------|
+| Traefik  | 443  |
+| ArgoCD   | 8443 |
+| HAProxy  | 9443 |
+
+MetalLB is configured with a single shared `orch-pool` instead of three separate pools.
+Services coexist on the same IP using `metallb.universe.tf/allow-shared-ip` annotations.
+
+## Deployment Instructions
+
+### Prerequisites
+
+- A Linux VM with at least 30GB disk, 8+ CPU cores, 32GB+ RAM
+- A single IP address for the orchestrator
+- Docker Hub credentials (for pulling rate-limited images)
+- Network connectivity to `registry-rs.edgeorchestration.intel.com`
+
+### Coder Notes
+
+- Ensure you have sufficient space in the root and user directories. 64 GB recommended.
+
+- Ensure the ORCH_DOMAIN variable is set. Reboot your coder instance if it is not.
+
+### Step 1: Clone the repository
+
+```bash
+git clone https://github.com/open-edge-platform/edge-manageability-framework.git
+cd edge-manageability-framework/on-prem-installers/onprem
+```
+
+Check out the branch containing the single-IP fixes (until merged to main):
+
+```bash
+git checkout single-ip
+```
+
+### Step 2: Configure onprem.env
+
+Edit `onprem.env` and set the following values:
+
+```bash
+# Set to the branch where this PR is checked in
+export DEPLOY_REPO_BRANCH="single-ip"
+
+# Docker Hub credentials (required to avoid pull rate limits)
+export DOCKER_USERNAME=<your-dockerhub-username>
+export DOCKER_PASSWORD=<your-dockerhub-password>
+
+# Your cluster domain (must resolve to ORCH_IP from browsers/clients)
+# For coder environments, set CLUSTER_DOMAIN to the value of your coder ORCH_DOMAIN.
+export CLUSTER_DOMAIN=<your-domain>
+
+# Single-IP mode: set ORCH_IP to your VM's IP address
+# Leave ARGO_IP, TRAEFIK_IP, HAPROXY_IP empty
+export ORCH_IP='<your-ip>'
+```
+
+**If behind a corporate proxy**, also set:
+
+```bash
+export ORCH_HTTP_PROXY="http://<proxy-host>:<port>"
+export ORCH_HTTPS_PROXY="http://<proxy-host>:<port>"
+
+# CRITICAL: ORCH_NO_PROXY must include Kubernetes-internal DNS suffixes.
+# Go's HTTP client matches no_proxy by hostname, not resolved IP.
+# Without these entries, in-cluster traffic goes through the proxy and fails
+# with x509 certificate errors.
+export ORCH_NO_PROXY="localhost,svc,cluster.local,default,internal,\
+127.0.0.0/8,10.0.0.0/8,192.168.0.0/16,172.16.0.0/12,169.254.169.254,\
+orch-platform,orch-app,orch-cluster,orch-infra,orch-database,cattle-system,\
+orch-secret,argocd-repo-server,\
+<your-site-specific-no-proxy-entries>"
+```
+
+The required `no_proxy` entries are:
+
+| Entry | Purpose |
+|-------|---------|
+| `svc` | Matches all `*.svc` short service names |
+| `cluster.local` | Matches all `*.svc.cluster.local` FQDNs |
+| `default` | Matches `kubernetes.default` (K8s API) |
+| `internal` | Matches `*.internal` |
+| `orch-platform`, `orch-app`, etc. | Matches namespace-scoped service names |
+| `argocd-repo-server` | ArgoCD internal communication |
+
+Also adjust the EN_*_PROXY as appropriate.
+
+### Step 3: Install K3s
+
+```bash
+bash pre-orch-install.sh k3s install
+```
+
+This installs K3s with Traefik and local-storage disabled (replaced by MetalLB and
+OpenEBS respectively), and max-pods set to 500.
+
+### Step 4: Deploy Edge Orchestrator
+
+```bash
+bash post-orch-install.sh -y
+```
+
+The `-y` flag runs non-interactively. This installs ArgoCD, Gitea, generates the
+cluster YAML, and deploys the root-app which triggers all other applications.
+
+Monitor deployment progress:
+
+```bash
+kubectl get app -A
+```
+
+Installation is complete when all applications show `Healthy` and `Synced`.
+This typically takes 10-15 minutes.
+
+### Step 5: Trust the self-signed CA certificate
+
+The deployment uses a self-signed CA issued by cert-manager. Clients (orch-cli,
+browsers, curl) will reject the TLS certificate unless the CA is added to the
+host's trust store:
+
+**Linux (Ubuntu/Debian):**
+
+```bash
+kubectl get secret tls-orch -n orch-gateway -o jsonpath='{.data.ca\.crt}' \
+  | base64 -d | sudo tee /usr/local/share/ca-certificates/orch-ca.crt > /dev/null
+sudo update-ca-certificates
+```
+
+**Windows (for browser access):**
+
+First, extract the CA cert on the Linux host:
+
+```bash
+kubectl get secret tls-orch -n orch-gateway -o jsonpath='{.data.ca\.crt}' \
+  | base64 -d > orch-ca.crt
+```
+
+Copy `orch-ca.crt` to the Windows machine (e.g., via `scp`), then import it:
+
+1. Double-click `orch-ca.crt` and click **Install Certificate...**
+2. Select **Local Machine**, click Next
+3. Select **Place all certificates in the following store**, click Browse
+4. Choose **Trusted Root Certification Authorities**, click OK, then Next, then Finish
+
+Alternatively, from an elevated PowerShell:
+
+```powershell
+Import-Certificate -FilePath .\orch-ca.crt -CertStoreLocation Cert:\LocalMachine\Root
+```
+
+Restart your browser after importing the certificate.
+
+### Step 6: Configure orch-cli and setup multitenancy
+
+Install the `orch-cli` binary if not already available, then configure the endpoint
+and log in.
+
+**Note:** The following example uses ORCH_DOMAIN which is usually set inside Coder
+environments.
+
+```bash
+export ADMIN_USERNAME=admin
+export ADMIN_PASSWORD=`kubectl -n orch-platform get secret platform-keycloak -o jsonpath='{.data.admin-password}' | base64 -d && echo`
+orch-cli config set api-endpoint https://api.$ORCH_DOMAIN
+orch-cli login $ADMIN_USERNAME $ADMIN_PASSWORD
+```
+
+```bash
+export PROJECT_USERNAME=sample-project-edge-mgr
+export PROJECT_PASSWORD=<fill-me-in>
+orch-cli set user admin --add-group org-admin-group
+orch-cli create organization sample-org
+ORG_ID=$(orch-cli get organization sample-org | awk '/^UID:/ {print $2}')
+ORCH_PASSWORD=$PROJECT_PASSWORD orch-cli create user $PROJECT_USERNAME --password
+orch-cli set user $PROJECT_USERNAME --add-group ${ORG_ID}_Project-Manager-Group
+orch-cli login $PROJECT_USERNAME $PROJECT_PASSWORD
+orch-cli create project sample-project
+PROJECT_ID=$(orch-cli get project sample-project | awk '/^UID:/ {print $2}')
+sleep 30s  # wait for project groups to be created
+orch-cli login $ADMIN_USERNAME $ADMIN_PASSWORD
+orch-cli set user $PROJECT_USERNAME --add-group ${PROJECT_ID}_Edge-Manager-Group
+orch-cli set user $PROJECT_USERNAME --add-group ${PROJECT_ID}_Edge-Onboarding-Group
+orch-cli set user $PROJECT_USERNAME --add-group ${PROJECT_ID}_Edge-Operator-Group
+orch-cli set user $PROJECT_USERNAME --add-group ${PROJECT_ID}_Host-Manager-Group
+```
+
+### Step 7: Configure DNS
+
+**Note:** This step is not needed on our Coder development environments.
+Coder automatically creates a wildcard DNS record that resolves all subdomains to
+the VM's IP address.
+
+For non-Coder environments, add the orchestrator hostnames to `/etc/hosts` on any
+machine that needs to access it. Note that using `/etc/hosts` will not suffice for
+provisioning edge nodes using UEFI-HTTP. You will have to come up with a real DNS
+solution to resolve that.
+
+The following script generates the entries:
+
+```bash
+#!/bin/bash
+# Usage: generate-hosts.sh <ip> <domain>
+# Outputs /etc/hosts entries for all orchestrator subdomains.
+
+if [ $# -ne 2 ]; then
+  echo "Usage: $0 <ip> <domain>" >&2
+  exit 1
+fi
+
+IP=$1
+DOMAIN=$2
+
+SUBDOMAINS=(
+  web-ui api keycloak vault registry-oci
+  observability-ui observability-admin alerting-monitor
+  gitea app-orch app-service-proxy ws-app-service-proxy vnc
+  docs-ui cluster-management connect-gateway fleet metadata
+  infra-node update-node telemetry-node attest-node
+  cluster-orch-node onboarding-node onboarding-stream
+  device-manager-node logs-node metrics-node release
+  tinkerbell-server tinkerbell-haproxy
+  mps mps-wss rps rps-wss
+)
+
+echo "$IP $DOMAIN"
+for sub in "${SUBDOMAINS[@]}"; do
+  echo "$IP ${sub}.${DOMAIN}"
+done
+```
+
+Run it and append to `/etc/hosts`
+
+Alternatively, configure a wildcard DNS record (`*.<domain>` -> `<your-ip>`) to avoid
+maintaining individual entries.
+
+### Step 8: Access the orchestrator
+
+- **Web UI:** `https://web-ui.<domain>`
+- **ArgoCD:** `https://<domain>:8443`
+- **Keycloak:** `https://keycloak.<domain>`
+- **Grafana:** `https://observability-ui.<domain>`
+
+### Destroying the K3s Cluster
+
+To completely destroy the deployment and remove K3s from the host:
+
+```bash
+cd edge-manageability-framework/on-prem-installers/onprem
+bash pre-orch-install.sh k3s uninstall
+```
+
+This runs the K3s uninstall script, which stops all K3s services, removes all
+containers and pods, deletes the K3s data directory, and removes the K3s binary.
+After uninstalling, the following artifacts may remain and can be cleaned up manually:
+
+```bash
+# Remove the kubeconfig
+rm -f ~/.kube/config
+
+# Remove the self-signed CA from the trust store (if installed)
+sudo rm -f /usr/local/share/ca-certificates/orch-ca.crt
+sudo update-ca-certificates
+
+# Remove /etc/hosts entries (if added)
+# Edit /etc/hosts and remove the orchestrator lines
+```
+
+After cleanup, the VM is ready for a fresh deployment starting from Step 3.
+
+## Files Modified
+
+| File | Changes |
+|------|---------|
+| `on-prem-installers/onprem/pre-orch-install.sh` | max-pods 200->500, node registration wait loop |
+| `on-prem-installers/onprem/post-orch-install.sh` | ORCH_IP non-interactive check, ArgoCD shared-IP annotations |
+| `on-prem-installers/onprem/onprem.env` | ORCH_IP variable, proxy documentation |
+| `on-prem-installers/onprem/cluster_onprem.tpl` | Added `singleIpMode` and `haproxyPort` values |
+| `installer/generate_cluster_yaml.sh` | Corrected Helm value paths for ArgoCD and HAProxy ports, export `HAPROXY_PORT` |
+| `argocd/applications/custom/infra-onboarding.tpl` | Conditional `:haproxyPort` on `provisioningSvc` and `nginxDnsname` |
+| `argocd/applications/templates/metallb-config.yaml` | Reverted to upstream orch-utils chart (v26.1.0) with single-IP support |
+
+`orch-utils` contains a fix to MetalLB to allow creation of a shared IP pool.
+That change has been merged.

--- a/argocd/applications/custom/infra-onboarding.tpl
+++ b/argocd/applications/custom/infra-onboarding.tpl
@@ -76,7 +76,7 @@ infra-config:
     systemConfigKernelPanic: "{{ index .Values.argo "infra-onboarding" "systemConfigKernelPanic" | default "10" }}"
 
     cdnSvc: {{ .Values.argo.releaseService.fileServer }}
-    provisioningSvc: tinkerbell-haproxy.{{ .Values.argo.clusterDomain }}
+    provisioningSvc: tinkerbell-haproxy.{{ .Values.argo.clusterDomain }}{{ if ne (.Values.argo.haproxyPort | default "443" | toString) "443" }}:{{ .Values.argo.haproxyPort }}{{ end }}
     tinkerSvc: tinkerbell-server.{{ .Values.argo.clusterDomain }}
     omSvc: onboarding-node.{{ .Values.argo.clusterDomain }}
     omStreamSvc: onboarding-stream.{{ .Values.argo.clusterDomain }}
@@ -104,7 +104,7 @@ tinkerbell:
   traefikReverseProxy:
     enabled: &traefikReverseProxy_enabled true
     tinkServerDnsname: "tinkerbell-server.{{ .Values.argo.clusterDomain }}"
-    nginxDnsname: &nginxDnsname "tinkerbell-haproxy.{{ .Values.argo.clusterDomain }}"
+    nginxDnsname: &nginxDnsname "tinkerbell-haproxy.{{ .Values.argo.clusterDomain }}{{ if ne (.Values.argo.haproxyPort | default "443" | toString) "443" }}:{{ .Values.argo.haproxyPort }}{{ end }}"
   stack:
     enabled: true
     resources:

--- a/argocd/applications/templates/metallb-config.yaml
+++ b/argocd/applications/templates/metallb-config.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: common/charts/{{$appName}}
-      targetRevision: 26.0.1
+      targetRevision: 26.1.0
       helm:
         releaseName: {{$appName}}
         valuesObject:

--- a/installer/generate_cluster_yaml.sh
+++ b/installer/generate_cluster_yaml.sh
@@ -201,6 +201,11 @@ if [ "$DEPLOY_TYPE" = "onprem" ]; then
     # Defaults for multi-IP mode (overridden below if ORCH_IP is set)
     export SINGLE_IP_MODE="false"
     export HAPROXY_PORT="443"
+    export ARGOCD_PORT="443"
+    export METALLB_ARGOCD_POOL="argocd-server"
+    export METALLB_TRAEFIK_POOL="traefik"
+    export METALLB_HAPROXY_POOL="haproxy-controller"
+    export METALLB_SHARED_IP_ANNOTATION=""
 
     # Single-IP mode: if ORCH_IP is set, use it for all three services
     if [ -n "${ORCH_IP:-}" ]; then
@@ -209,9 +214,14 @@ if [ "$DEPLOY_TYPE" = "onprem" ]; then
         export HAPROXY_IP="$ORCH_IP"
         export SINGLE_IP_MODE="true"
         export HAPROXY_PORT="9443"
+        export ARGOCD_PORT="8443"
+        export METALLB_ARGOCD_POOL="orch-pool"
+        export METALLB_TRAEFIK_POOL="orch-pool"
+        export METALLB_HAPROXY_POOL="orch-pool"
+        export METALLB_SHARED_IP_ANNOTATION="metallb.universe.tf/allow-shared-ip: orch-services"
         echo
         echo "✅ Single-IP mode: all services will share $ORCH_IP"
-        echo "   ArgoCD port:     8443"
+        echo "   ArgoCD port:     ${ARGOCD_PORT}"
         echo "   Traefik port:    443"
         echo "   HAProxy port:    ${HAPROXY_PORT}"
         echo
@@ -392,31 +402,6 @@ fi
 
 if [ "${DISABLE_UI_PROFILE:-false}" = "true" ]; then
     yq -i '.argo.enabled.metadata-broker = false' "$OUTPUT_FILE"
-fi
-
-# -----------------------------------------------------------------------------
-# Single-IP mode: reconfigure MetalLB and service ports
-# -----------------------------------------------------------------------------
-# When ORCH_IP is set, all services share one IP on different ports:
-#   - Traefik:    443 (unchanged)
-#   - ArgoCD:     8443
-#   - HAProxy:    9443
-# The local metallb-config chart (charts/metallb-config) detects when all three
-# IPs are identical and creates a single shared pool named "orch-pool" instead of
-# three separate pools. Services must use allow-shared-ip annotations and
-# different ports to coexist on the same IP.
-if [ "${SINGLE_IP_MODE:-false}" = "true" ]; then
-    echo "🔧 Applying single-IP mode overrides..."
-    yq -i '
-      .postCustomTemplateOverwrite.argocd.server.service.annotations."metallb.universe.tf/address-pool" = "orch-pool" |
-      .postCustomTemplateOverwrite.argocd.server.service.annotations."metallb.universe.tf/allow-shared-ip" = "orch-services" |
-      .postCustomTemplateOverwrite.argocd.server.service.servicePortHttps = 8443 |
-      .postCustomTemplateOverwrite.traefik.service.annotations."metallb.universe.tf/address-pool" = "orch-pool" |
-      .postCustomTemplateOverwrite.traefik.service.annotations."metallb.universe.tf/allow-shared-ip" = "orch-services" |
-      .postCustomTemplateOverwrite.ingress-haproxy.controller.service.annotations."metallb.universe.tf/address-pool" = "orch-pool" |
-      .postCustomTemplateOverwrite.ingress-haproxy.controller.service.annotations."metallb.universe.tf/allow-shared-ip" = "orch-services" |
-      .postCustomTemplateOverwrite.ingress-haproxy.controller.service.ports.https = 9443
-    ' "$OUTPUT_FILE"
 fi
 
 # -----------------------------------------------------------------------------

--- a/installer/generate_cluster_yaml.sh
+++ b/installer/generate_cluster_yaml.sh
@@ -198,17 +198,37 @@ fi
 # On-prem specific logic
 # -----------------------------------------------------------------------------
 if [ "$DEPLOY_TYPE" = "onprem" ]; then
-    # Prompt for required IPs
-    prompt_for_ip "ARGO_IP" "Argo IP"
-    prompt_for_ip "TRAEFIK_IP" "Traefik IP"
-    prompt_for_ip "HAPROXY_IP" "HAProxy IP"
+    # Defaults for multi-IP mode (overridden below if ORCH_IP is set)
+    export SINGLE_IP_MODE="false"
+    export HAPROXY_PORT="443"
 
-    echo
-    echo "✅ Using the following valid IPs:"
-    echo "   ArgoIP:     $ARGO_IP"
-    echo "   TraefikIP:  $TRAEFIK_IP"
-    echo "   HaproxyIP:  $HAPROXY_IP"
-    echo
+    # Single-IP mode: if ORCH_IP is set, use it for all three services
+    if [ -n "${ORCH_IP:-}" ]; then
+        export ARGO_IP="$ORCH_IP"
+        export TRAEFIK_IP="$ORCH_IP"
+        export HAPROXY_IP="$ORCH_IP"
+        export SINGLE_IP_MODE="true"
+        export HAPROXY_PORT="9443"
+        echo
+        echo "✅ Single-IP mode: all services will share $ORCH_IP"
+        echo "   ArgoCD port:     8443"
+        echo "   Traefik port:    443"
+        echo "   HAProxy port:    ${HAPROXY_PORT}"
+        echo
+    else
+        # Multi-IP mode: prompt for three separate IPs
+        prompt_for_ip "ARGO_IP" "Argo IP"
+        prompt_for_ip "TRAEFIK_IP" "Traefik IP"
+        prompt_for_ip "HAPROXY_IP" "HAProxy IP"
+        export SINGLE_IP_MODE="false"
+
+        echo
+        echo "✅ Using the following valid IPs:"
+        echo "   ArgoIP:     $ARGO_IP"
+        echo "   TraefikIP:  $TRAEFIK_IP"
+        echo "   HaproxyIP:  $HAPROXY_IP"
+        echo
+    fi
 
     # O11Y disable check
     if [ "${DISABLE_O11Y_PROFILE:-false}" = "true" ]; then
@@ -372,6 +392,31 @@ fi
 
 if [ "${DISABLE_UI_PROFILE:-false}" = "true" ]; then
     yq -i '.argo.enabled.metadata-broker = false' "$OUTPUT_FILE"
+fi
+
+# -----------------------------------------------------------------------------
+# Single-IP mode: reconfigure MetalLB and service ports
+# -----------------------------------------------------------------------------
+# When ORCH_IP is set, all services share one IP on different ports:
+#   - Traefik:    443 (unchanged)
+#   - ArgoCD:     8443
+#   - HAProxy:    9443
+# The local metallb-config chart (charts/metallb-config) detects when all three
+# IPs are identical and creates a single shared pool named "orch-pool" instead of
+# three separate pools. Services must use allow-shared-ip annotations and
+# different ports to coexist on the same IP.
+if [ "${SINGLE_IP_MODE:-false}" = "true" ]; then
+    echo "🔧 Applying single-IP mode overrides..."
+    yq -i '
+      .postCustomTemplateOverwrite.argocd.server.service.annotations."metallb.universe.tf/address-pool" = "orch-pool" |
+      .postCustomTemplateOverwrite.argocd.server.service.annotations."metallb.universe.tf/allow-shared-ip" = "orch-services" |
+      .postCustomTemplateOverwrite.argocd.server.service.servicePortHttps = 8443 |
+      .postCustomTemplateOverwrite.traefik.service.annotations."metallb.universe.tf/address-pool" = "orch-pool" |
+      .postCustomTemplateOverwrite.traefik.service.annotations."metallb.universe.tf/allow-shared-ip" = "orch-services" |
+      .postCustomTemplateOverwrite.ingress-haproxy.controller.service.annotations."metallb.universe.tf/address-pool" = "orch-pool" |
+      .postCustomTemplateOverwrite.ingress-haproxy.controller.service.annotations."metallb.universe.tf/allow-shared-ip" = "orch-services" |
+      .postCustomTemplateOverwrite.ingress-haproxy.controller.service.ports.https = 9443
+    ' "$OUTPUT_FILE"
 fi
 
 # -----------------------------------------------------------------------------

--- a/on-prem-installers/onprem/cluster_onprem.tpl
+++ b/on-prem-installers/onprem/cluster_onprem.tpl
@@ -40,6 +40,7 @@ argo:
   clusterDomain: ${CLUSTER_DOMAIN}
   singleIpMode: ${SINGLE_IP_MODE}
   haproxyPort: ${HAPROXY_PORT}
+  argocdPort: ${ARGOCD_PORT}
 
   ## Argo CD configs
   deployRepoURL: "https://github.com/open-edge-platform/edge-manageability-framework"
@@ -70,17 +71,23 @@ postCustomTemplateOverwrite:
   argocd:
     server:
       service:
+        servicePortHttps: ${ARGOCD_PORT}
         annotations:
-          metallb.universe.tf/address-pool: argocd-server
+          metallb.universe.tf/address-pool: ${METALLB_ARGOCD_POOL}
+          ${METALLB_SHARED_IP_ANNOTATION}
   traefik:
     service:
       annotations:
-        metallb.universe.tf/address-pool: traefik
+        metallb.universe.tf/address-pool: ${METALLB_TRAEFIK_POOL}
+        ${METALLB_SHARED_IP_ANNOTATION}
   ingress-haproxy:
     controller:
       service:
+        ports:
+          https: ${HAPROXY_PORT}
         annotations:
-          metallb.universe.tf/address-pool: haproxy-controller
+          metallb.universe.tf/address-pool: ${METALLB_HAPROXY_POOL}
+          ${METALLB_SHARED_IP_ANNOTATION}
   metallb-config:
     ArgoIP: ${ARGO_IP}
     TraefikIP: ${TRAEFIK_IP}

--- a/on-prem-installers/onprem/cluster_onprem.tpl
+++ b/on-prem-installers/onprem/cluster_onprem.tpl
@@ -38,6 +38,8 @@ argo:
   # name to produce the service's domain name. For example, given the domain name of `orchestrator.io`, the Web UI
   # service will be accessible via `web-ui.orchestrator.io`. Not to be confused with the K8s cluster domain.
   clusterDomain: ${CLUSTER_DOMAIN}
+  singleIpMode: ${SINGLE_IP_MODE}
+  haproxyPort: ${HAPROXY_PORT}
 
   ## Argo CD configs
   deployRepoURL: "https://github.com/open-edge-platform/edge-manageability-framework"

--- a/on-prem-installers/onprem/onprem.env
+++ b/on-prem-installers/onprem/onprem.env
@@ -38,7 +38,12 @@ export DOCKER_PASSWORD=
 # Cluster domain name for internal services (Required)
 export CLUSTER_DOMAIN=cluster.onprem
 
-# MetalLB Load Balancer IP addresses (Required)
+# MetalLB Load Balancer IP addresses
+# Option 1: Set ORCH_IP to use a single IP for all services (single-IP mode).
+#   Services will share the IP on different ports: Traefik:443, ArgoCD:8443, HAProxy:9443.
+#   This is useful for environments with limited IP addresses (e.g., Coder VMs).
+# Option 2: Set ARGO_IP, TRAEFIK_IP, and HAPROXY_IP individually (multi-IP mode).
+export ORCH_IP=''
 export ARGO_IP=''
 export TRAEFIK_IP=''
 export HAPROXY_IP=''
@@ -85,10 +90,28 @@ export OXM_PXE_SERVER_SUBNET=""
 # PROXY CONFIGURATION
 # =============================================================================
 export ENABLE_EXPLICIT_PROXY=false
+
 # ORCH Proxy Configuration
+# IMPORTANT: ORCH_NO_PROXY MUST include Kubernetes-internal DNS suffixes so that
+# in-cluster service-to-service traffic is not routed through the corporate proxy.
+# Go's HTTP/gRPC clients match no_proxy against the request hostname (not resolved IP),
+# so IP-based entries like 10.0.0.0/8 do NOT cover hostnames like "kubernetes.default"
+# or "inventory.orch-infra.svc.cluster.local".
+#
+# Required entries for ORCH_NO_PROXY (in addition to your site-specific entries):
+#   svc                - matches all *.svc short names
+#   cluster.local      - matches all *.cluster.local FQDNs
+#   default            - matches kubernetes.default
+#   internal           - matches *.internal
+#   orch-platform,orch-app,orch-cluster,orch-infra,orch-database,orch-secret,cattle-system
+#                      - matches namespace-scoped service names
+#
+# Example for Intel corporate proxy:
+#   ORCH_NO_PROXY="localhost,svc,cluster.local,default,internal,127.0.0.0/8,10.0.0.0/8,192.168.0.0/16,172.16.0.0/12,169.254.169.254,orch-platform,orch-app,orch-cluster,orch-infra,orch-database,cattle-system,orch-secret,argocd-repo-server"
 export ORCH_HTTP_PROXY=""
 export ORCH_HTTPS_PROXY=""
 export ORCH_NO_PROXY=""
+
 # EN Proxy Configuration
 export EN_HTTP_PROXY=""
 export EN_HTTPS_PROXY=""

--- a/on-prem-installers/onprem/post-orch-install.sh
+++ b/on-prem-installers/onprem/post-orch-install.sh
@@ -117,8 +117,8 @@ generate_cluster_yaml_onprem_from_upstream() {
   local out_file="$cwd/${ORCH_INSTALLER_PROFILE}.yaml"
 
   if [[ "$ASSUME_YES" == "true" ]]; then
-    if [[ -z "${ARGO_IP:-}" || -z "${TRAEFIK_IP:-}" || -z "${HAPROXY_IP:-}" ]]; then
-      echo "❌ ARGO_IP, TRAEFIK_IP, and HAPROXY_IP must be set when running non-interactively (-y)"
+    if [[ -z "${ORCH_IP:-}" ]] && [[ -z "${ARGO_IP:-}" || -z "${TRAEFIK_IP:-}" || -z "${HAPROXY_IP:-}" ]]; then
+      echo "❌ ORCH_IP (or ARGO_IP, TRAEFIK_IP, and HAPROXY_IP) must be set when running non-interactively (-y)"
       exit 1
     fi
   fi
@@ -582,9 +582,20 @@ EOF
   # NOTE: values.tmpl sets server.service.type=LoadBalancer. On kind (and other
   # clusters without a LB provider ready), helm --wait will block waiting for an
   # external IP. We rely on pod readiness instead.
+  local -a argocd_extra_args=()
+  if [[ "${ORCH_IP:-}" != "" ]]; then
+    # Single-IP mode: ArgoCD shares the IP with Traefik and HAProxy on port 8443
+    argocd_extra_args+=(
+      --set 'server.service.annotations.metallb\.universe\.tf/address-pool=orch-pool'
+      --set 'server.service.annotations.metallb\.universe\.tf/allow-shared-ip=orch-services'
+      --set 'server.service.servicePortHttps=8443'
+    )
+  fi
+
   helm upgrade --install argocd "$tmp/argo-cd" \
     --values "$tmp/values.yaml" \
     -f "$tmp/mounts.yaml" \
+    "${argocd_extra_args[@]}" \
     -n "$argo_cd_ns" --create-namespace --timeout 15m0s
 
   wait_for_pods_running "$argo_cd_ns"

--- a/on-prem-installers/onprem/pre-orch-install.sh
+++ b/on-prem-installers/onprem/pre-orch-install.sh
@@ -160,6 +160,16 @@ wait_for_k8s_ready() {
   done
   echo "✅ API server is ready"
 
+  echo "👉 Waiting for at least one node to register..."
+  local deadline=$((SECONDS + WAIT_TIMEOUT_SECONDS))
+  until kubectl "${kubectl_ctx_args[@]}" get nodes -o name 2>/dev/null | grep -q .; do
+    if (( SECONDS >= deadline )); then
+      echo "❌ Timed out waiting for a node to register after ${WAIT_TIMEOUT_SECONDS}s"
+      exit 1
+    fi
+    sleep "${WAIT_INTERVAL_SECONDS}"
+  done
+
   echo "👉 Waiting for all nodes to be Ready (timeout: ${WAIT_TIMEOUT_SECONDS}s)..."
   if ! kubectl "${kubectl_ctx_args[@]}" wait --for=condition=Ready node --all --timeout="${WAIT_TIMEOUT_SECONDS}s"; then
     echo "❌ Timed out waiting for nodes to become Ready"
@@ -371,7 +381,7 @@ k3s_install() {
       --write-kubeconfig-mode=0644 \
       --disable traefik \
       --disable local-storage \
-      --kubelet-arg=max-pods=200
+      --kubelet-arg=max-pods=500
   fi
 
   if [[ "${registries_written}" == "true" ]]; then


### PR DESCRIPTION
### Description

Standard on-prem deployments require three IP addresses for MetalLB LoadBalancer services. This is impractical for Coder VMs and other constrained environments that only have a single IP. Single-IP mode removes this barrier by assigning each service a unique port on the shared IP.

* Preserve full compatibility with existing multiple IP address deployments. This is the default.
* Add single-IP deployment mode for on-prem K3s installations. Instead of requiring three separate IPs for ArgoCD, Traefik, and HAProxy, operators can set ORCH_IP in onprem.env to share a single IP across all three services on different ports (443, 8443, 9443). 
* Fix tinkerbell provisioning URLs to include the HAProxy port in single-IP mode, so PXE boot works correctly via iDRAC/iPXE.
* Fix ORCH_NO_PROXY documentation to include Kubernetes-internal DNS suffixes required for proxy environments.
* Increase K3s max-pods to 500 and add a node registration wait loop to improve install reliability.
* Switch metallb-config to the upstream orch-utils chart (v26.1.0) which now supports single-IP pool creation.


Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
