### PR TITLE
add adr for nexus tenancy-datamodel replacement

### DIFF
--- a/design-proposals/platform-nexus-replacement.md
+++ b/design-proposals/platform-nexus-replacement.md
@@ -114,17 +114,37 @@ tenancy endpoints:
   assumes Traefik has already validated -- it always verifies the JWT itself.
   This defense-in-depth protects against direct ClusterIP access,
   port-forwarding, and misconfigured IngressRoutes.
-- **RBAC:** Authorization rules are implemented in Go middleware (not OPA),
-  matching the current Rego policy for the six tenancy roles:
+- **RBAC:** Authorization rules are implemented in Go middleware rather than
+  an OPA sidecar. The other services (app-deployment-api, app-resource-manager,
+  app-orch-catalog, infra-core) use OPA sidecars successfully because their
+  authorization is a binary allow/deny gate: the rest-proxy resolves the
+  project name to a UUID, injects an `ActiveProjectID` header, and OPA checks
+  whether the JWT contains the required role (e.g., `{projectUID}_ao-rw`).
+  All context OPA needs is available in request headers before the service
+  is reached.
+
+  The Tenant Manager's authorization does not fit this model for two reasons:
+
+  1. **Query-scoped filtering:** `GET /v1/projects` must return only projects
+     in orgs the caller has access to. The middleware extracts org UUIDs from
+     JWT role patterns (`{orgUUID}_project-read-role`) and uses them to scope
+     the database query (WHERE clause). This is a result-set filter, not a
+     binary gate -- OPA cannot filter query results.
+  2. **Database-dependent evaluation:** For `GET /v1/projects/{name}`, the
+     middleware must look up which org owns the project (a database query)
+     before it can determine whether the caller has the required org-scoped
+     role. Unlike the other services, where `ActiveProjectID` is resolved
+     by the rest-proxy before OPA sees the request, the Tenant Manager
+     owns the data that authorization depends on -- there is no upstream
+     component to pre-resolve it.
+
+  The six tenancy roles enforced are:
   - Org endpoints: `org-read-role`, `org-write-role`, `org-delete-role`
     (global roles)
   - Project endpoints: `{orgId}_project-read-role`,
     `{orgId}_project-write-role`, `{orgId}_project-delete-role` (org-scoped)
   - Project read fallback: `{orgId}_{projectId}_member-role` grants read
     access
-- **Org scoping:** The auth middleware extracts org UUIDs from JWT roles and
-  scopes all project queries to the caller's orgs. This replaces the
-  nexus-api-gw's cache-based org/project resolution.
 - **Internal endpoints** (`/v1/events`, `/v1/status`) are ClusterIP-only and
   unauthenticated.
 

--- a/design-proposals/platform-nexus-replacement.md
+++ b/design-proposals/platform-nexus-replacement.md
@@ -2,7 +2,7 @@
 
 Author(s): Scott Baker
 
-Last updated: 4/9/26
+Last updated: 4/13/26
 
 ## Abstract
 
@@ -74,7 +74,10 @@ The tenancy-manager is rewritten as a standalone HTTP server that:
 - Exposes internal endpoints for controller event polling and status reporting
 - Derives resource status from the `controller_statuses` table against a
   Helm-managed config of registered controllers
-- Bootstraps default org/project on first startup (absorbing `tenancy-init`)
+- Optionally bootstraps default org/project on first startup (absorbing
+  `tenancy-init`). Bootstrap is skipped when `default_org_name` and
+  `default_project_name` are empty, allowing org/project creation to be
+  driven entirely by the deploy script or external tooling
 
 Controllers interact exclusively via the REST API -- they have no database
 dependency and no Ent schema dependency.
@@ -98,11 +101,50 @@ shared library (`orch-library/go/pkg/tenancy/`) that implements the
 replay-then-poll lifecycle. Business logic (provisioning, cleanup) is
 unchanged.
 
+### Authentication and Authorization
+
+The Tenant Manager absorbs the RBAC responsibilities of the nexus-api-gw for
+tenancy endpoints:
+
+- **JWT validation:** The Tenant Manager validates JWT signatures on every
+  request using `orch-library/go/pkg/auth.JwtAuthenticator.ParseAndValidate()`,
+  which verifies against Keycloak JWKS. This is the authoritative validation.
+  Traefik's `validate-jwt` middleware (Kyverno-enforced on all IngressRoutes)
+  provides an additional layer at the ingress, but the Tenant Manager never
+  assumes Traefik has already validated -- it always verifies the JWT itself.
+  This defense-in-depth protects against direct ClusterIP access,
+  port-forwarding, and misconfigured IngressRoutes.
+- **RBAC:** Authorization rules are implemented in Go middleware (not OPA),
+  matching the current Rego policy for the six tenancy roles:
+  - Org endpoints: `org-read-role`, `org-write-role`, `org-delete-role`
+    (global roles)
+  - Project endpoints: `{orgId}_project-read-role`,
+    `{orgId}_project-write-role`, `{orgId}_project-delete-role` (org-scoped)
+  - Project read fallback: `{orgId}_{projectId}_member-role` grants read
+    access
+- **Org scoping:** The auth middleware extracts org UUIDs from JWT roles and
+  scopes all project queries to the caller's orgs. This replaces the
+  nexus-api-gw's cache-based org/project resolution.
+- **Internal endpoints** (`/v1/events`, `/v1/status`) are ClusterIP-only and
+  unauthenticated.
+
 ### API Exposure
 
 The Tenant Manager gets a Traefik IngressRoute for external CRUD endpoints.
+The IngressRoute must include the `validate-jwt` middleware (Kyverno-enforced).
 Internal event/status endpoints are ClusterIP-only. The orch-library project
 context middleware is updated to resolve project UUIDs via the Tenant Manager.
+
+Four services have rest-proxy sidecars that resolve project names to UUIDs.
+Each must be configured to point at the Tenant Manager instead of the old
+nexus-api-gw:
+
+| Service | Flag |
+| --- | --- |
+| app-deployment-api | `-nexus-api-url` |
+| app-resource-manager | `-nexus-api-url` |
+| apiv2 (infra-core) | `-nexusAPIURL` |
+| app-orch-catalog | `-project-service-url` |
 
 ### Components Removed
 
@@ -182,6 +224,19 @@ is available.
 1. **Existing data migration:** Live deployments have tenancy state in etcd
    CRDs. A one-time migration tool or procedure is needed to seed the Postgres
    tables from the existing CRDs before cutting over.
-2. **Nexus API gateway removal scope:** The nexus-api-gw also serves as an API
-   remapper for non-tenancy services. Its full removal depends on the separate
-   API remapper migration and is out of scope for this proposal.
+2. **Nexus API gateway catch-all route:** The nexus-api-gw has a Traefik
+   IngressRoute with `PathPrefix('/v')` that catches ALL `/v*` API paths not
+   matched by a more specific IngressRoute. In the replacement, the
+   nexus-api-gw can no longer resolve projects (it still reads the old nexus
+   datamodel), so any path that falls through returns **403**. The
+   nexus-api-gw also performed **path remapping** between external paths (what
+   the UI calls) and internal service paths. For example, the UI calls
+   `/v1/projects/{project}/summary/deployments_status` but the service expects
+   `/v1/projects/{project}/appdeployment/summary/deployments_status`. These
+   unmapped paths require new Traefik IngressRoutes with `ReplacePathRegex`
+   middleware. Full nexus-api-gw removal depends on mapping all affected paths
+   and is out of scope for this proposal.
+3. **Inconsistent rest-proxy flag names:** The four services with project
+   resolver URLs each use a different flag name (`-nexus-api-url`,
+   `-nexusAPIURL`, `-project-service-url`). A future cleanup should
+   standardize on a single flag name across all rest-proxy sidecars.

--- a/design-proposals/platform-nexus-replacement.md
+++ b/design-proposals/platform-nexus-replacement.md
@@ -31,7 +31,7 @@ Replace the Nexus CRD/etcd data model with five Postgres tables managed by
 the Ent ORM framework (same pattern as `infra-core/inventory/`):
 
 | Table | Purpose |
-|---|---|
+| --- | --- |
 | `orgs` | Organization with soft-delete (`deleted_at`) |
 | `folders` | Org→Folder hierarchy (one "default" folder per org, no CRUD API) |
 | `projects` | Folder→Project with soft-delete |
@@ -84,7 +84,7 @@ dependency and no Ent schema dependency.
 All seven tenant controllers are refactored:
 
 | Controller | Canonical ID | Events |
-|---|---|---|
+| --- | --- | --- |
 | app-orch | `app-orch-tenant-controller` | project |
 | keycloak | `keycloak-tenant-controller` | **org + project** |
 | infra-core | `infra-tenant-controller` | project |
@@ -152,7 +152,7 @@ migrations run).
 ## Affected Components and Teams
 
 | Component | Repository | Change |
-|---|---|---|
+| --- | --- | --- |
 | tenancy-manager | `orch-utils` | Full rewrite (Nexus → HTTP server + Ent) |
 | keycloak-tenant-controller | `orch-utils` | Replace Nexus SDK with shared library |
 | app-orch-tenant-controller | `app-orch-tenant-controller` | Replace Nexus SDK with shared library |

--- a/design-proposals/platform-nexus-replacement.md
+++ b/design-proposals/platform-nexus-replacement.md
@@ -1,0 +1,187 @@
+# Design Proposal: Nexus Tenancy Replacement
+
+Author(s): Scott Baker
+
+Last updated: 4/9/26
+
+## Abstract
+
+The EMF tenancy data model (orgs, folders, projects) is currently implemented
+using the Nexus framework: CRDs in Kubernetes etcd, a generated Go SDK, and an
+event-driven watcher/acknowledgment protocol coordinated by the tenancy-manager.
+Seven tenant controllers subscribe to CRD events to provision resources in
+external systems (Keycloak, Harbor, K8s namespaces, inventory, etc.).
+
+This proposal replaces the Nexus-based tenancy implementation with a
+Postgres-backed design using the Ent ORM and a new Tenant Manager REST API.
+The Nexus SDK, tenancy CRDs, and the watcher protocol are removed from all
+components.
+
+This builds on the direction established in the
+[Multi-tenancy Simplification](edge-manageability-framework/design-proposals/platform-multi-tenancy-simplification.md)
+proposal (Moon, Togashi), which introduced the Tenant Manager REST API and
+Traefik IngressRoutes. This proposal extends that work by replacing the
+underlying data store and event propagation mechanism.
+
+## Proposal
+
+### Data Store
+
+Replace the Nexus CRD/etcd data model with five Postgres tables managed by
+the Ent ORM framework (same pattern as `infra-core/inventory/`):
+
+| Table | Purpose |
+|---|---|
+| `orgs` | Organization with soft-delete (`deleted_at`) |
+| `folders` | Org→Folder hierarchy (one "default" folder per org, no CRUD API) |
+| `projects` | Folder→Project with soft-delete |
+| `tenancy_events` | Event log for org/project create and delete |
+| `controller_statuses` | Per-controller, per-resource status tracking |
+
+Hash names are eliminated -- Postgres uses the user-friendly name directly,
+with UUID primary keys.
+
+### Event Propagation
+
+Replace the Nexus callback/watcher protocol with a transactional event table
+and polling:
+
+1. **Transactional writes:** When the Tenant Manager creates or deletes an org
+   or project, it writes the data change and a `tenancy_events` row in the
+   same database transaction. If the data committed, the event committed.
+
+2. **Controller polling:** Each controller polls the Tenant Manager REST API
+   on startup (replay from current DB state) and then at a regular interval
+   (incremental events). Controllers report per-resource status back to the
+   Tenant Manager, which derives overall org/project status.
+
+3. **Delete lifecycle:** Controllers delete their `controller_statuses` row
+   after successfully processing a delete event (mirroring the current
+   `DeleteActiveWatchers()` pattern). The Tenant Manager hard-deletes
+   soft-deleted resources when no status rows from registered controllers
+   remain.
+
+This approach requires no new infrastructure (uses existing Postgres), no
+push-based mechanisms, and is compatible with cloud-hosted databases like
+Amazon Aurora (standard SQL only).
+
+### Tenant Manager
+
+The tenancy-manager is rewritten as a standalone HTTP server that:
+
+- Owns the Postgres tenancy schema (sole database accessor)
+- Exposes REST endpoints for org/project CRUD (`/v1/orgs`, `/v1/projects`)
+- Exposes internal endpoints for controller event polling and status reporting
+- Derives resource status from the `controller_statuses` table against a
+  Helm-managed config of registered controllers
+- Bootstraps default org/project on first startup (absorbing `tenancy-init`)
+
+Controllers interact exclusively via the REST API -- they have no database
+dependency and no Ent schema dependency.
+
+### Controller Refactoring
+
+All seven tenant controllers are refactored:
+
+| Controller | Canonical ID | Events |
+|---|---|---|
+| app-orch | `app-orch-tenant-controller` | project |
+| keycloak | `keycloak-tenant-controller` | **org + project** |
+| infra-core | `infra-tenant-controller` | project |
+| cluster-manager | `cluster-manager` | project |
+| app-deployment-mgr | `app-deployment-manager` | project |
+| observability | `observability-tenant-controller` | project |
+| metadata-broker | `metadata-broker` | project |
+
+Each controller removes its Nexus SDK integration and replaces it with a
+shared library (`orch-library/go/pkg/tenancy/`) that implements the
+replay-then-poll lifecycle. Business logic (provisioning, cleanup) is
+unchanged.
+
+### API Exposure
+
+The Tenant Manager gets a Traefik IngressRoute for external CRUD endpoints.
+Internal event/status endpoints are ClusterIP-only. The orch-library project
+context middleware is updated to resolve project UUIDs via the Tenant Manager.
+
+### Components Removed
+
+- Tenancy data model CRDs (`orch-utils/tenancy-datamodel/`)
+- `tenancy-init` job (`orch-utils/tenancy-init/`)
+- Nexus SDK dependency from all seven controllers, the tenancy-manager, and
+  the nexus-api-gw
+
+## Rationale
+
+### Why not keep Nexus CRDs?
+
+- Tenancy data in etcd is not backed up alongside other data in Postgres,
+  creating a split-brain risk for disaster recovery.
+- The Nexus framework adds significant complexity (CRD generation, hash names,
+  watcher protocol, finalizer-based deletion) for what is a simple
+  hierarchical data model.
+- The Nexus SDK is tightly coupled to Kubernetes, making cloud-hosted database
+  migration impossible.
+
+### Why not a message queue / event bus?
+
+The requirements explicitly exclude additional infrastructure. Postgres is
+already deployed. The transactional event table provides the same durability
+guarantees as a queue for this use case (low event volume, seconds-level
+latency acceptable).
+
+### Why polling instead of LISTEN/NOTIFY?
+
+LISTEN/NOTIFY is Postgres-specific and not supported by Amazon Aurora or other
+cloud database services. Polling at 5-second intervals is negligible overhead
+for tenancy operations, which involve slow external provisioning (Harbor,
+Keycloak, K8s namespace creation).
+
+### Why Ent ORM?
+
+Already in use in `infra-core/inventory/` with 28 schemas, versioned
+migrations, and a store layer. Using the same framework avoids introducing a
+second data access pattern.
+
+### Why controllers access the REST API, not Postgres directly?
+
+Avoids database technology coupling, schema dependency proliferation across
+seven controllers, and startup ordering issues (controller starting before
+migrations run).
+
+## Affected Components and Teams
+
+| Component | Repository | Change |
+|---|---|---|
+| tenancy-manager | `orch-utils` | Full rewrite (Nexus → HTTP server + Ent) |
+| keycloak-tenant-controller | `orch-utils` | Replace Nexus SDK with shared library |
+| app-orch-tenant-controller | `app-orch-tenant-controller` | Replace Nexus SDK with shared library |
+| infra-core tenant-controller | `infra-core` | Replace Nexus SDK with shared library |
+| cluster-manager | `cluster-manager` | Replace Nexus SDK with shared library |
+| app-deployment-manager | `app-orch-deployment` | Replace Nexus SDK with shared library |
+| observability-tenant-controller | `o11y-tenant-controller` | Replace Nexus SDK with shared library |
+| metadata-broker | `orch-metadata-broker` | Replace Nexus SDK with shared library |
+| orch-library | `orch-library` | New shared tenancy polling library + middleware update |
+| tenancy-datamodel | `orch-utils` | Removed |
+| tenancy-init | `orch-utils` | Removed (absorbed by Tenant Manager) |
+| CLI | `orch-cli` | Regenerate API client |
+| UI | `orch-ui` | Regenerate API client |
+| Helm charts | various | Add Ent migrations, update controller config, remove CRDs |
+
+All work to be done by platform team.
+
+## Implementation Plan
+
+This is a big-bang replacement -- all components must be updated together.
+The detailed implementation plan, including Ent schemas, REST API contracts,
+per-controller migration details, and a 21-step phased implementation order,
+is available.
+
+## Open Issues
+
+1. **Existing data migration:** Live deployments have tenancy state in etcd
+   CRDs. A one-time migration tool or procedure is needed to seed the Postgres
+   tables from the existing CRDs before cutting over.
+2. **Nexus API gateway removal scope:** The nexus-api-gw also serves as an API
+   remapper for non-tenancy services. Its full removal depends on the separate
+   API remapper migration and is out of scope for this proposal.


### PR DESCRIPTION
### Description

New ADR for replacing Nexus-based tenancy-api-datamodel with a postgres-based service.

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
