### PR TITLE
fix(component-status): add cors middleware to IngressRoute for orchestrator clock

### DIFF
--- a/argocd/applications/custom/component-status.tpl
+++ b/argocd/applications/custom/component-status.tpl
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Intel Corporation
+# SPDX-FileCopyrightText: 2026 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -26,6 +26,7 @@ traefikRoute:
   secretName: tls-orch
   middlewares:
     - validate-jwt
+    - cors
     - secure-headers
 {{- if .Values.argo.traefik }}
   tlsOption: {{ .Values.argo.traefik.tlsOption | default "" | quote }}


### PR DESCRIPTION
### Description

The cors Traefik middleware must be present in the component-status IngressRoute so the browser receives Access-Control-Allow-Origin and Access-Control-Expose-Headers: Date headers. Without cors the browser blocks the CORS fetch entirely and the UI clock falls back to local time.

The cors Middleware spec already includes accessControlExposeHeaders: [Date] (traefik-extra-objects chart).  This change wires it into the route.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
