### PR TITLE
Bump KeycloakVersion to 26.6.0 | helmFile deploy

### DIFF
--- a/helmfile-deploy/post-orch/helmfile.yaml.gotmpl
+++ b/helmfile-deploy/post-orch/helmfile.yaml.gotmpl
@@ -87,7 +87,7 @@ releases:
     namespace: orch-platform
     chart: edge-orch/common/charts/keycloak-operator
     wait: true
-    version: 26.1.2
+    version: 26.1.3
     values:
       - values/keycloak-operator.yaml
     condition: keycloak-operator.enabled
@@ -386,7 +386,7 @@ releases:
     namespace: orch-platform
     chart: edge-orch/common/charts/keycloak-instance
     wait: true
-    version: 26.1.2
+    version: 26.1.3
     timeout: 600
     values:
       - values/platform-keycloak.yaml.gotmpl

--- a/helmfile-deploy/post-orch/values/keycloak-operator.yaml
+++ b/helmfile-deploy/post-orch/values/keycloak-operator.yaml
@@ -2,5 +2,23 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-#
-# Values for keycloak-operator
+
+# Disable operator trace export to localhost:4317 to avoid repeated warning logs
+# while preserving upstream-required environment variables.
+operator:
+  container:
+    env:
+      - name: KUBERNETES_NAMESPACE
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.namespace
+      - name: RELATED_IMAGE_KEYCLOAK
+        value: '{{ "{{ .Values.operator.relatedImage.keycloak }}" }}'
+      - name: QUARKUS_OPERATOR_SDK_CONTROLLERS_KEYCLOAKREALMIMPORTCONTROLLER_NAMESPACES
+        value: JOSDK_WATCH_CURRENT
+      - name: QUARKUS_OPERATOR_SDK_CONTROLLERS_KEYCLOAKCONTROLLER_NAMESPACES
+        value: JOSDK_WATCH_CURRENT
+      # Runtime key to disable OTel SDK and stop OTLP export warnings.
+      # QUARKUS_OTEL_TRACES_EXPORTER is a build-time property and is not effective here.
+      - name: QUARKUS_OTEL_SDK_DISABLED
+        value: "true"


### PR DESCRIPTION

### Description
Update the keycloak version to 26.6.0 in helm deploy way

Fixes # (issue) : https://jira.devtools.intel.com/browse/ITEP-90343

### Any Newly Introduced Dependencies
Keycloak 26.6.0

### How Has This Been Tested?
CI

### Checklist:
- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
