### PR TITLE
Fix slow package pulls by adding country code to terraform and cloud-init

### DIFF
--- a/terraform/orchestrator/cloud-inits/cloud_config.tftpl
+++ b/terraform/orchestrator/cloud-inits/cloud_config.tftpl
@@ -22,6 +22,14 @@ ntp:
     - ${ntp_server}
 %{ endif ~}
 apt:
+%{ if apt_mirror_country != "" ~}
+  primary:
+    - arches: [amd64, i386]
+      uri: http://${apt_mirror_country}.archive.ubuntu.com/ubuntu/
+  security:
+    - arches: [amd64, i386]
+      uri: http://${apt_mirror_country}.archive.ubuntu.com/ubuntu/
+%{ endif ~}
 %{ if http_proxy != "" ~}
   http_proxy: ${http_proxy}
 %{ endif ~}

--- a/terraform/orchestrator/cloud-inits/cloud_config.tftpl
+++ b/terraform/orchestrator/cloud-inits/cloud_config.tftpl
@@ -1,6 +1,6 @@
 #cloud-config
 
-# SPDX-FileCopyrightText: 2025 Intel Corporation
+# SPDX-FileCopyrightText: 2026 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/terraform/orchestrator/main.tf
+++ b/terraform/orchestrator/main.tf
@@ -388,61 +388,61 @@ resource "null_resource" "exec_installer" {
   provisioner "remote-exec" {
     inline = [
       "set -o errexit",
-      "bash -c 'cd /home/ubuntu; source onprem.env; ./onprem_installer.sh --yes --trace ${var.use_local_build_artifact ? "--skip-download" : ""} -- --yes --trace | tee ./install_output.log; exit $${PIPESTATUS[0]}'",
+        "echo 'Starting on-prem installer...'",
     ]
     when = create
   }
 }
 
-resource "null_resource" "wait_for_kubeconfig" {
+# resource "null_resource" "wait_for_kubeconfig" {
 
-  // Disable this resource if auto-install is disabled
-  count = var.enable_auto_install ? 1 : 0
+#   // Disable this resource if auto-install is disabled
+#   count = var.enable_auto_install ? 1 : 0
 
-  depends_on = [
-    null_resource.exec_installer
-  ]
+#   depends_on = [
+#     null_resource.exec_installer
+#   ]
 
-  connection {
-    type     = "ssh"
-    host     = local.vmnet_ip0
-    port     = var.vm_ssh_port
-    user     = var.vm_ssh_user
-    password = var.vm_ssh_password
-  }
+#   connection {
+#     type     = "ssh"
+#     host     = local.vmnet_ip0
+#     port     = var.vm_ssh_port
+#     user     = var.vm_ssh_user
+#     password = var.vm_ssh_password
+#   }
 
-  provisioner "remote-exec" {
-    inline = [
-      "until test -f /home/${var.vm_ssh_user}/.kube/config; do sleep 15; done", // This takes ~10 minutes - patience!
-      "echo 'KUBECONFIG file exists!'",
-    ]
-    when = create
-  }
-}
+#   provisioner "remote-exec" {
+#     inline = [
+#       "until test -f /home/${var.vm_ssh_user}/.kube/config; do sleep 15; done", // This takes ~10 minutes - patience!
+#       "echo 'KUBECONFIG file exists!'",
+#     ]
+#     when = create
+#   }
+# }
 
-resource "null_resource" "copy_kubeconfig" {
+# resource "null_resource" "copy_kubeconfig" {
 
-  // Disable this resource if auto-install is disabled
-  count = var.enable_auto_install ? 1 : 0
+#   // Disable this resource if auto-install is disabled
+#   count = var.enable_auto_install ? 1 : 0
 
-  depends_on = [
-    null_resource.wait_for_kubeconfig
-  ]
+#   depends_on = [
+#     null_resource.wait_for_kubeconfig
+#   ]
 
-  provisioner "local-exec" {
-    command = "rm ${path.module}/files/kubeconfig || true"
-    when    = create
-  }
+#   provisioner "local-exec" {
+#     command = "rm ${path.module}/files/kubeconfig || true"
+#     when    = create
+#   }
 
-  provisioner "local-exec" {
-    command = "SSH_PASSWORD='${var.vm_ssh_password}' ${path.module}/scripts/sshpass.bash scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -P 22 ${var.vm_ssh_user}@${local.vmnet_ip0}:/home/${var.vm_ssh_user}/.kube/config ${path.module}/files/kubeconfig"
-    when    = create
-  }
+#   provisioner "local-exec" {
+#     command = "SSH_PASSWORD='${var.vm_ssh_password}' ${path.module}/scripts/sshpass.bash scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -P 22 ${var.vm_ssh_user}@${local.vmnet_ip0}:/home/${var.vm_ssh_user}/.kube/config ${path.module}/files/kubeconfig"
+#     when    = create
+#   }
 
-  provisioner "local-exec" {
-    // Set the cluster URL to the VM's IP address so that kubectl can remotely connect to the cluster. Disable TLS
-    // verification because the server name dialed does not match the certificate.
-    command = "KUBECONFIG=${path.module}/files/kubeconfig kubectl config set-cluster default --server=https://${local.vmnet_ip0}:6443 --insecure-skip-tls-verify=true"
-    when    = create
-  }
-}
+#   provisioner "local-exec" {
+#     // Set the cluster URL to the VM's IP address so that kubectl can remotely connect to the cluster. Disable TLS
+#     // verification because the server name dialed does not match the certificate.
+#     command = "KUBECONFIG=${path.module}/files/kubeconfig kubectl config set-cluster default --server=https://${local.vmnet_ip0}:6443 --insecure-skip-tls-verify=true"
+#     when    = create
+#   }
+# }

--- a/terraform/orchestrator/main.tf
+++ b/terraform/orchestrator/main.tf
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Intel Corporation
+# SPDX-FileCopyrightText: 2026 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -389,61 +389,61 @@ resource "null_resource" "exec_installer" {
   provisioner "remote-exec" {
     inline = [
       "set -o errexit",
-        "echo 'Starting on-prem installer...'",
+      "bash -c 'cd /home/ubuntu; source onprem.env; ./onprem_installer.sh --yes --trace ${var.use_local_build_artifact ? "--skip-download" : ""} -- --yes --trace | tee ./install_output.log; exit $${PIPESTATUS[0]}'",
     ]
     when = create
   }
 }
 
-# resource "null_resource" "wait_for_kubeconfig" {
+resource "null_resource" "wait_for_kubeconfig" {
 
-#   // Disable this resource if auto-install is disabled
-#   count = var.enable_auto_install ? 1 : 0
+  // Disable this resource if auto-install is disabled
+  count = var.enable_auto_install ? 1 : 0
 
-#   depends_on = [
-#     null_resource.exec_installer
-#   ]
+  depends_on = [
+    null_resource.exec_installer
+  ]
 
-#   connection {
-#     type     = "ssh"
-#     host     = local.vmnet_ip0
-#     port     = var.vm_ssh_port
-#     user     = var.vm_ssh_user
-#     password = var.vm_ssh_password
-#   }
+  connection {
+    type     = "ssh"
+    host     = local.vmnet_ip0
+    port     = var.vm_ssh_port
+    user     = var.vm_ssh_user
+    password = var.vm_ssh_password
+  }
 
-#   provisioner "remote-exec" {
-#     inline = [
-#       "until test -f /home/${var.vm_ssh_user}/.kube/config; do sleep 15; done", // This takes ~10 minutes - patience!
-#       "echo 'KUBECONFIG file exists!'",
-#     ]
-#     when = create
-#   }
-# }
+  provisioner "remote-exec" {
+    inline = [
+      "until test -f /home/${var.vm_ssh_user}/.kube/config; do sleep 15; done", // This takes ~10 minutes - patience!
+      "echo 'KUBECONFIG file exists!'",
+    ]
+    when = create
+  }
+}
 
-# resource "null_resource" "copy_kubeconfig" {
+resource "null_resource" "copy_kubeconfig" {
 
-#   // Disable this resource if auto-install is disabled
-#   count = var.enable_auto_install ? 1 : 0
+  // Disable this resource if auto-install is disabled
+  count = var.enable_auto_install ? 1 : 0
 
-#   depends_on = [
-#     null_resource.wait_for_kubeconfig
-#   ]
+  depends_on = [
+    null_resource.wait_for_kubeconfig
+  ]
 
-#   provisioner "local-exec" {
-#     command = "rm ${path.module}/files/kubeconfig || true"
-#     when    = create
-#   }
+  provisioner "local-exec" {
+    command = "rm ${path.module}/files/kubeconfig || true"
+    when    = create
+  }
 
-#   provisioner "local-exec" {
-#     command = "SSH_PASSWORD='${var.vm_ssh_password}' ${path.module}/scripts/sshpass.bash scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -P 22 ${var.vm_ssh_user}@${local.vmnet_ip0}:/home/${var.vm_ssh_user}/.kube/config ${path.module}/files/kubeconfig"
-#     when    = create
-#   }
+  provisioner "local-exec" {
+    command = "SSH_PASSWORD='${var.vm_ssh_password}' ${path.module}/scripts/sshpass.bash scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -P 22 ${var.vm_ssh_user}@${local.vmnet_ip0}:/home/${var.vm_ssh_user}/.kube/config ${path.module}/files/kubeconfig"
+    when    = create
+  }
 
-#   provisioner "local-exec" {
-#     // Set the cluster URL to the VM's IP address so that kubectl can remotely connect to the cluster. Disable TLS
-#     // verification because the server name dialed does not match the certificate.
-#     command = "KUBECONFIG=${path.module}/files/kubeconfig kubectl config set-cluster default --server=https://${local.vmnet_ip0}:6443 --insecure-skip-tls-verify=true"
-#     when    = create
-#   }
-# }
+  provisioner "local-exec" {
+    // Set the cluster URL to the VM's IP address so that kubectl can remotely connect to the cluster. Disable TLS
+    // verification because the server name dialed does not match the certificate.
+    command = "KUBECONFIG=${path.module}/files/kubeconfig kubectl config set-cluster default --server=https://${local.vmnet_ip0}:6443 --insecure-skip-tls-verify=true"
+    when    = create
+  }
+}

--- a/terraform/orchestrator/main.tf
+++ b/terraform/orchestrator/main.tf
@@ -14,6 +14,7 @@ resource "local_file" "cloud_init_user_data_file" {
       no_proxy            = var.no_proxy,
       ca_certs            = [for ca_cert_paths in var.ca_certificates : indent(6, file(ca_cert_paths))], // Read CA certs into a list
       enable_auto_install = var.enable_auto_install,
+      apt_mirror_country  = var.apt_mirror_country,
     },
   )
   filename = "${path.module}/files/user_data.cfg"

--- a/terraform/orchestrator/variables.tf
+++ b/terraform/orchestrator/variables.tf
@@ -140,6 +140,12 @@ variable "ca_certificates" {
   default     = []
 }
 
+variable "apt_mirror_country" {
+  type        = string
+  description = "Country code for Ubuntu apt mirrors (e.g., 'us', 'de', 'uk'). Uses country-specific mirrors for faster package downloads."
+  default     = "us"
+}
+
 variable "install_docker" {
   type        = bool
   description = "Whether to install Docker on the VM."


### PR DESCRIPTION
### Description

This PR addresses the slow package installation issue by adding country code to both the terraform template and cloud-init configuration. 

This ensures that the Ubuntu package manager uses the appropriate regional mirror instead of the default global mirror, significantly reducing package download times from ~10 minutes back to seconds.

Default to US.

Fixes # (issue)

### Any Newly Introduced Dependencies

n/a
### How Has This Been Tested?

ci and locally

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
