### PR TITLE
Fixing cooldown issue in code scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,8 @@ updates:
       prefix: "Go modules"
     reviewers:
       - "dmytroye"
+    cooldown:
+      default-days: 7
 
   # Terraform
   - package-ecosystem: "terraform"
@@ -37,6 +39,8 @@ updates:
       prefix: "terraform"
     reviewers:
       - "dmytroye"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "terraform"
     directory: "/terraform/orchestrator"
@@ -51,6 +55,8 @@ updates:
       prefix: "terraform"
     reviewers:
       - "dmytroye"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "terraform"
     directory: "/terraform/edge-storage-pool"
@@ -65,6 +71,8 @@ updates:
       prefix: "terraform"
     reviewers:
       - "dmytroye"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "terraform"
     directory: "/pod-configs/orchestrator/cluster"
@@ -79,6 +87,8 @@ updates:
       prefix: "terraform"
     reviewers:
       - "dmytroye"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "terraform"
     directory: "/pod-configs/orchestrator/orch-load-balancer"
@@ -93,6 +103,8 @@ updates:
       prefix: "terraform"
     reviewers:
       - "dmytroye"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "terraform"
     directory: "/pod-configs/orchestrator/orch-route53"
@@ -107,6 +119,8 @@ updates:
       prefix: "terraform"
     reviewers:
       - "dmytroye"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "terraform"
     directory: "/pod-configs/orchestrator/pull-through-cache-proxy"
@@ -121,6 +135,8 @@ updates:
       prefix: "terraform"
     reviewers:
       - "dmytroye"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "terraform"
     directory: "/pod-configs/module/lb-target-group-attachment"
@@ -135,6 +151,8 @@ updates:
       prefix: "terraform"
     reviewers:
       - "dmytroye"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "terraform"
     directory: "/pod-configs/module/application-load-balancer"
@@ -149,6 +167,8 @@ updates:
       prefix: "terraform"
     reviewers:
       - "dmytroye"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "terraform"
     directory: "/pod-configs/module/load-balancer"
@@ -163,6 +183,8 @@ updates:
       prefix: "terraform"
     reviewers:
       - "dmytroye"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "terraform"
     directory: "/pod-configs/buckets"
@@ -177,6 +199,8 @@ updates:
       prefix: "terraform"
     reviewers:
       - "dmytroye"
+    cooldown:
+      default-days: 7
 
   # Helm
   - package-ecosystem: "helm"
@@ -193,6 +217,8 @@ updates:
       prefix: "Helm"
     reviewers:
       - "dmytroye"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "helm"
     directory: "/argocd-internal/root-app"
@@ -208,6 +234,8 @@ updates:
       prefix: "Helm"
     reviewers:
       - "dmytroye"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "helm"
     directory: "/argocd/applications"
@@ -223,6 +251,8 @@ updates:
       prefix: "Helm"
     reviewers:
       - "dmytroye"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "helm"
     directory: "/argocd/root-app"
@@ -238,6 +268,8 @@ updates:
       prefix: "Helm"
     reviewers:
       - "dmytroye"
+    cooldown:
+      default-days: 7
 
   # Docker
   - package-ecosystem: "docker"
@@ -254,6 +286,8 @@ updates:
       prefix: "Dockerfile"
     reviewers:
       - "dmytroye"
+    cooldown:
+      default-days: 7
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
@@ -265,3 +299,5 @@ updates:
       prefix: "Github Actions"
     reviewers:
       - "dmytroye"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
This pull request updates the `.github/dependabot.yml` configuration to introduce a cooldown period for all managed package ecosystems. The cooldown setting ensures that Dependabot will wait 7 days between creating new pull requests for dependency updates in each specified directory, helping to reduce noise and batch updates.

Key changes:

**Dependabot Cooldown Configuration:**

* Added a `cooldown` section with `default-days: 7` to all Go modules, Terraform, Helm, Docker, and GitHub Actions update configurations, ensuring Dependabot waits 7 days between update PRs for each ecosystem and directory. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R25-R26) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R42-R43) [[3]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R58-R59) [[4]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R74-R75) [[5]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R90-R91) [[6]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R106-R107) [[7]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R122-R123) [[8]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R138-R139) [[9]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R154-R155) [[10]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R170-R171) [[11]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R186-R187) [[12]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R202-R203) [[13]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R220-R221) [[14]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R237-R238) [[15]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R254-R255) [[16]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R271-R272) [[17]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R289-R290) [[18]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R302-R303)

This change helps manage the frequency of dependency update PRs, making them more predictable and less overwhelming for reviewers.