### PR TITLE
Bump cert-manager to 1.20.2

### DIFF
--- a/argocd/applications/templates/cert-manager.yaml
+++ b/argocd/applications/templates/cert-manager.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: https://charts.jetstack.io
       chart: cert-manager
-      targetRevision: 1.19.3
+      targetRevision: 1.20.2
       helm:
         releaseName: {{$appName}}
         valuesObject:


### PR DESCRIPTION
### Description

Bump cert-manager to 1.20.2

Fixes # (issue)

### Any Newly Introduced Dependencies

n/a

### How Has This Been Tested?

ci

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
