### PR TITLE
Bump external-secrets to 2.5.0

### DIFF
--- a/argocd/applications/templates/external-secrets.yaml
+++ b/argocd/applications/templates/external-secrets.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: https://charts.external-secrets.io
       chart: external-secrets
-      targetRevision: 2.0.1
+      targetRevision: 2.5.0
       helm:
         releaseName: {{$appName}}
         valuesObject:


### PR DESCRIPTION
### Description

Bump external-secrets to 2.5.0

Fixes # (issue)

### Any Newly Introduced Dependencies

n/a

### How Has This Been Tested?

ci

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
