### PR TITLE
Bump infra-managers to 2.18.1

### DIFF
--- a/argocd/applications/templates/infra-managers.yaml
+++ b/argocd/applications/templates/infra-managers.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: infra/charts/{{$appName}}
-      targetRevision: 2.18.0
+      targetRevision: 2.18.1
       helm:
         releaseName: {{$appName}}
         valuesObject:


### PR DESCRIPTION
### Description

Bump infra-managers to 2.18.1 to bring in the changes from this PR https://github.com/open-edge-platform/infra-managers/pull/650 

Fixes # (issue)

### Any Newly Introduced Dependencies

n/a

### How Has This Been Tested?

ci

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
