### PR TITLE
Bump infra-managers to 2.18.1 in the Helm deploy branch

### DIFF
--- a/post-orch/helmfile.yaml.gotmpl
+++ b/post-orch/helmfile.yaml.gotmpl
@@ -895,7 +895,7 @@ releases:
     namespace: orch-infra
     chart: edge-orch/infra/charts/infra-managers
     wait: true
-    version: 2.18.0
+    version: 2.18.1
     values:
       - values/infra-managers.yaml.gotmpl
       - values/resource-overrides.yaml


### PR DESCRIPTION
### Description

Bump infra-managers to 2.18.1 to bring in the changes from this PR https://github.com/open-edge-platform/infra-managers/pull/650 

Fixes # (issue)

### Any Newly Introduced Dependencies

n/a

### How Has This Been Tested?

ci

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
