### PR TITLE
amt/mps: replace vault-token refresh CronJob with long-running Deployment for exact 50-min cadence

### DIFF
--- a/post-orch/helmfile.yaml.gotmpl
+++ b/post-orch/helmfile.yaml.gotmpl
@@ -880,7 +880,7 @@ releases:
     namespace: orch-infra
     chart: edge-orch/infra/charts/infra-external
     wait: true
-    version: 2.14.5
+    version: 2.14.6
     values:
       - values/infra-external.yaml.gotmpl
     condition: infra-external.enabled

--- a/post-orch/values/infra-external.yaml.gotmpl
+++ b/post-orch/values/infra-external.yaml.gotmpl
@@ -99,6 +99,9 @@ loca-credentials:
 
 amt:
   mps:
+    refresher:
+     intervalSeconds: 3000
+     livenessMaxAgeSeconds: 3300
     postgresql:
       image:
         tag: 16.10-bookworm


### PR DESCRIPTION
### Description

The existing schedule: "*/50 * * * *" CronJob does not produce an even 50-minute cadence. Cron evaluates the /50 expression per hour, so jobs fire at :00 and :50 — giving a 50/10/50/10 minute alternating pattern. A KVM/SOL session started just after the :50 refresh is killed by Reloader only ~10 minutes later when the :00 job fires and rewrites the vault-token Secret. There is no cron expression that can deliver a true 50-minute period (50 does not divide 60 evenly), so an in-process sleep loop is the only correct fix

https://github.com/open-edge-platform/infra-charts/pull/395

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
