### PR TITLE
Enable post-merge security scans for tag creation

### DIFF
--- a/.github/workflows/virtual-integration.yml
+++ b/.github/workflows/virtual-integration.yml
@@ -13,6 +13,8 @@ on:
       - main
       - main-pass-validation
       - EMF_HELMDEPLOY_2026_01
+    tags:
+      - '*'
 
   # Trigger workflow on PRs to all branches
   pull_request:


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration, enabling the workflow to trigger on all tags. This ensures that the workflow will run whenever a tag is pushed, regardless of its name.