### PR TITLE
itep-90091: cleanup of auto-created cluster on host delete

### DIFF
--- a/argocd/applications/templates/cluster-manager.yaml
+++ b/argocd/applications/templates/cluster-manager.yaml
@@ -21,7 +21,7 @@ spec:
   sources:
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: cluster/charts/{{$appName}}
-      targetRevision: 2.2.12
+      targetRevision: 2.2.14
       helm:
         releaseName: {{$appName}}
         valuesObject:
@@ -33,7 +33,7 @@ spec:
           {{- mergeOverwrite $baseConfig $customConfig $overwrite | toYaml | nindent 10 }}
     - repoURL: {{ required "A valid chartRepoURL entry required!" .Values.argo.chartRepoURL }}
       chart: cluster/charts/cluster-template-crd
-      targetRevision: 2.2.12
+      targetRevision: 2.2.14
   destination:
     namespace: {{$namespace}}
     server: {{ required "A valid targetServer entry required!" .Values.argo.targetServer }}


### PR DESCRIPTION
### Description
This PR contains the cluster-manager changes to cleanup the cluster when the host gets deleted.
In the scenario when the cluster was created using 'auto-create' true

Fixes # (issue): ITEP-90091

### Any Newly Introduced Dependencies
NA

### How Has This Been Tested?
Coder

### Checklist:
- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
